### PR TITLE
docs: modernize and unify README.md as bilingual (EN/PT)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,201 +1,21 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+MIT License
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Copyright (c) 2025-2026 Isaque Pinheiro
 
-   1. Definitions.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# ModernSyntax: Functional Programming Toolkit for Delphi
+# ModernSyntax Functional Programming Toolkit for Delphi
 
-[![Delphi Supported Versions](https://img.shields.io/badge/Delphi%20Supported%20Versions-XE%2B-blue.svg)]()
+[![Delphi XE+](https://img.shields.io/badge/Delphi-XE%20or%20superior-blue.svg)]()
 [![License](https://img.shields.io/badge/License-LGPL--3.0-blue.svg)](LICENSE)
 
 *   [🇬🇧 English](#-english)
@@ -10,20 +10,30 @@
 
 ## 🇬🇧 English
 
-**ModernSyntax** is a high-performance, lightweight functional programming and modern syntax extension toolkit for Delphi. 
+**ModernSyntax** is a high-performance, lightweight functional programming and modern syntax extension toolkit for Delphi. It modernizes Delphi coding paradigms, bringing them on par with advanced features found in contemporary languages like **Rust**, **Kotlin**, **C#**, and **Haskell**. Designed to bridge native Pascal syntax limitations, ModernSyntax introduces safe optional types to prevent null-reference errors, functional error flows, advanced pattern matching, asynchronous task scheduling, and currying.
 
-It modernizes Delphi coding paradigms, bringing them on par with features found in advanced contemporary languages like **Rust**, **Kotlin**, **C#**, and **Haskell**. Designed to bridge native Pascal syntax limitations, ModernSyntax introduces safe optional types, functional error flows, advanced pattern matching, asynchronous task scheduling, and currying.
+### 🚀 Key Features
 
----
+*   **Null Safety (`TOption<T>`):** Enforces strict compile-time or runtime handling of optional values, preventing common Access Violations (null pointer exceptions) in the style of Rust or Haskell.
+*   **Functional Error Handling (`TResultPair<S, F>`):** Replaces untracked exceptions with a clean, functional success/failure return type.
+*   **Pattern Matching (`TMatch<T>`):** Expressive, type-safe matching structures to completely replace nested `if-else` or convoluted `case` statements.
+*   **Simplified Asynchrony (`TScheduler`):** Easily schedule background tasks with an *async/await* style wrapper, without manual thread synchronization.
+*   **Tuples & Destructuring (`TTuple<T>`):** Create lightweight, anonymous data structures (e.g., `(1, 'a', True)`) with direct value extraction.
+*   **Currying (`TCurrying`):** Introduces functional partial applications, bringing Scala and Haskell functional programming paradigms directly to Delphi.
 
-### 🚀 Key Features & Architectural Paradigms
+### 🏛 Compatibility Matrix
 
-*   **Null Safety (`TOption<T>`):** Prevents common null pointer exceptions. Enforces strict and safe handling of optional values, in the style of Rust or Haskell.
-*   **Functional Error Handling (`TResultPair<S, F>`):** Replaces messy or unpredicted exceptions with a clean, functional success/failure type.
-*   **Pattern Matching (`TMatch<T>`):** Write expressive, type-safe conditional structures. Completely replaces long `if-else` or `case` statements.
-*   **Simplified Asynchrony (`TScheduler`):** Introduces easy *async/await* task scheduling without the overhead of manual thread or task synchronization.
-*   **Tuples & Destructuring (`TTuple<T>`):** Creates lightweight, anonymous data structures (e.g., `(1, 'a', True)`) with direct value extraction.
-*   **Currying (`TCurrying`):** Introduces functional partial application (e.g., `f(x)(y)`), bringing Scala or Haskell paradigms to Delphi.
+| Environment / IDE | Platform / Compiler | Null Safety | Pattern Matching |
+| :--- | :--- | :---: | :---: |
+| **Delphi XE or superior** | VCL, FMX, Console (Win/Linux/macOS/iOS/Android) | ✅ Yes | ✅ Yes |
+
+### ⚙️ Installation
+
+To install using the package manager [**Boss**](https://github.com/HashLoad/boss):
+
+```sh
+boss install ModernSyntax
+```
 
 ---
 
@@ -31,12 +41,13 @@ It modernizes Delphi coding paradigms, bringing them on par with features found 
 
 #### 1. Null Safety (`TOption<T>`)
 ```delphi
-uses ModernSyntax.Option;
+uses
+  ModernSyntax.Option;
 
 var
   LName: TOption<string>;
 begin
-  // Create an optional value that may or may not exist
+  // Create an optional value
   LName := TOption<string>.Some('Isaque');
   
   if LName.HasValue then
@@ -44,14 +55,15 @@ begin
   else
     WriteLn('No value found.');
     
-  // Default fallback value
+  // Safe default fallback
   WriteLn(LName.ValueOrElse('Default Name'));
 end;
 ```
 
 #### 2. Pattern Matching (`TMatch<T>`)
 ```delphi
-uses ModernSyntax.Match;
+uses
+  ModernSyntax.Match;
 
 var
   LInput: Integer;
@@ -59,7 +71,6 @@ var
 begin
   LInput := 2;
   
-  // Clean, expressive matching
   LMessage := TMatch<Integer>.Create(LInput)
     .CaseOf(1, 'First place!')
     .CaseOf(2, 'Second place!')
@@ -73,7 +84,8 @@ end;
 
 #### 3. Functional Results (`TResultPair<S, F>`)
 ```delphi
-uses ModernSyntax.ResultPair;
+uses
+  ModernSyntax.ResultPair;
 
 function Divide(const A, B: Double): TResultPair<Double, string>;
 begin
@@ -86,31 +98,32 @@ end;
 
 ---
 
-### ⛏️ Contributing
-We love contributions! Feel free to open issues or submit pull requests.
-
-### 📬 Contact & Support
-*   **Telegram**: [HashLoad Channel](https://t.me/hashload)
-*   **Website**: [isaquepinheiro.com.br](https://www.isaquepinheiro.com.br)
-
----
-
 ## 🇧🇷 Português
 
-**ModernSyntax** é um kit de ferramentas de alta performance e peso-pena para programação funcional e extensão de sintaxe moderna para Delphi.
+**ModernSyntax** é um kit de ferramentas leve e de alta performance para programação funcional e extensão de sintaxe moderna em Delphi. Ele moderniza os paradigmas de codificação do Delphi, trazendo-os para o mesmo nível de recursos encontrados em linguagens contemporâneas avançadas como **Rust**, **Kotlin**, **C#** e **Haskell**. Desenvolvido para superar limitações da sintaxe nativa do Pascal, o ModernSyntax introduz tipos opcionais seguros para evitar erros de referência nula, fluxo de erros funcional, pattern matching avançado, agendamento assíncrono e currying.
 
-Ele moderniza os paradigmas de codificação do Delphi, trazendo-o para o mesmo nível de recursos encontrados em linguagens contemporâneas avançadas como **Rust**, **Kotlin**, **C#** e **Haskell**. Desenvolvido para superar limitações da sintaxe nativa do Pascal, o ModernSyntax introduz tipos opcionais seguros, fluxo de erros funcional, pattern matching avançado, agendamento assíncrono e currying.
+### 🚀 Recursos Principais
 
----
-
-### 🚀 Recursos Principais & Paradigmas de Arquitetura
-
-*   **Null Safety (`TOption<T>`):** Previne exceções clássicas de ponteiro nulo (Access Violation). Impõe a manipulação estrita e segura de valores opcionais, ao estilo de Rust ou Haskell.
-*   **Tratamento de Erro Funcional (`TResultPair<S, F>`):** Substitui exceções desorganizadas por um tipo limpo e funcional de sucesso/falha.
-*   **Pattern Matching (`TMatch<T>`):** Escreva estruturas condicionais expressivas e fortemente tipadas. Substitui cadeias complexas de `if-else` ou `case` de forma elegante.
-*   **Assincronia Simplificada (`TScheduler`):** Introduz o agendamento de tarefas ao estilo *async/await* sem a complexidade de sincronização manual de threads.
+*   **Null Safety (`TOption<T>`):** Impõe a manipulação estrita e segura de valores opcionais, prevenindo exceções clássicas de Access Violation (ponteiro nulo) ao estilo de Rust ou Haskell.
+*   **Tratamento de Erros Funcional (`TResultPair<S, F>`):** Substitui exceções desorganizadas por um tipo limpo e funcional de sucesso/falha no retorno de métodos.
+*   **Pattern Matching (`TMatch<T>`):** Estruturas condicionais expressivas e fortemente tipadas para substituir cadeias complexas de `if-else` ou blocos `case` limitados.
+*   **Assincronia Simplificada (`TScheduler`):** Agende e gerencie tarefas assíncronas ao estilo *async/await* sem a complexidade de sincronização manual de threads.
 *   **Tuplas & Desestruturação (`TTuple<T>`):** Cria estruturas leves de dados anônimos (ex: `(1, 'a', True)`) com extração direta de valores.
-*   **Currying (`TCurrying`):** Introduz a aplicação parcial de funções (ex: `f(x)(y)`), trazendo paradigmas do Scala ou Haskell para o Delphi.
+*   **Currying (`TCurrying`):** Introduz a aplicação parcial de funções, trazendo paradigmas de linguagens como Scala ou Haskell diretamente ao Delphi.
+
+### 🏛 Matriz de Compatibilidade
+
+| Ambiente / IDE | Plataforma / Compilador | Null Safety | Pattern Matching |
+| :--- | :--- | :---: | :---: |
+| **Delphi XE ou superior** | VCL, FMX, Console (Win/Linux/macOS/iOS/Android) | ✅ Sim | ✅ Sim |
+
+### ⚙️ Instalação
+
+Para instalar usando o gerenciador de pacotes [**Boss**](https://github.com/HashLoad/boss):
+
+```sh
+boss install ModernSyntax
+```
 
 ---
 
@@ -118,12 +131,13 @@ Ele moderniza os paradigmas de codificação do Delphi, trazendo-o para o mesmo 
 
 #### 1. Null Safety (`TOption<T>`)
 ```delphi
-uses ModernSyntax.Option;
+uses
+  ModernSyntax.Option;
 
 var
   LName: TOption<string>;
 begin
-  // Cria um valor opcional que pode ou não existir
+  // Cria um valor opcional
   LName := TOption<string>.Some('Isaque');
   
   if LName.HasValue then
@@ -138,7 +152,8 @@ end;
 
 #### 2. Pattern Matching (`TMatch<T>`)
 ```delphi
-uses ModernSyntax.Match;
+uses
+  ModernSyntax.Match;
 
 var
   LInput: Integer;
@@ -146,7 +161,6 @@ var
 begin
   LInput := 2;
   
-  // Casamento de padrões expressivo e limpo
   LMessage := TMatch<Integer>.Create(LInput)
     .CaseOf(1, 'Primeiro lugar!')
     .CaseOf(2, 'Segundo lugar!')
@@ -160,7 +174,8 @@ end;
 
 #### 3. Resultados Funcionais (`TResultPair<S, F>`)
 ```delphi
-uses ModernSyntax.ResultPair;
+uses
+  ModernSyntax.ResultPair;
 
 function Dividir(const A, B: Double): TResultPair<Double, string>;
 begin
@@ -170,15 +185,6 @@ begin
     Result := TResultPair<Double, string>.Success(A / B);
 end;
 ```
-
----
-
-### ⛏️ Contribuição
-Adoramos contribuições! Sinta-se à vontade para abrir issues ou enviar pull requests.
-
-### 📬 Contato & Suporte
-*   **Telegram**: [Canal HashLoad](https://t.me/hashload)
-*   **Website**: [isaquepinheiro.com.br](https://www.isaquepinheiro.com.br)
 
 ---
 *Copyright © 2025-2026 Isaque Pinheiro. Licensed under LGPL-3.0 License.*

--- a/README.md
+++ b/README.md
@@ -1,25 +1,184 @@
 # ModernSyntax: Functional Programming Toolkit for Delphi
 
-Welcome to **ModernSyntax** — a solution that modernizes Delphi, bringing it on par with today’s most advanced languages like Rust, Kotlin, and Python. If you’re a Delphi developer who loves the language’s robustness but misses contemporary features such as *pattern matching*, *null safety*, *async/await*, or functional programming, ModernSyntax is for you. Designed to bridge the gaps in native Delphi, this toolkit provides powerful tools that boost productivity, reduce errors, and make your code more elegant and maintainable.
+[![Delphi Supported Versions](https://img.shields.io/badge/Delphi%20Supported%20Versions-XE%2B-blue.svg)]()
+[![License](https://img.shields.io/badge/License-LGPL--3.0-blue.svg)](LICENSE)
 
-## Why ModernSyntax?
+*   [🇬🇧 English](#-english)
+*   [🇧🇷 Português](#-português)
 
-Delphi remains a legend in desktop and enterprise development, but the programming world has evolved. Features like *Option/Maybe*, *Result/Either*, *tuples*, and *currying*—common in modern languages—are either absent or limited in native Delphi. ModernSyntax changes that by offering:
+---
 
-- **Null Safety:** With `TOption<T>`, say goodbye to null pointer errors. Enforce safe handling of optional values, akin to Rust or Haskell.
-- **Typed Results:** Replace chaotic exceptions with `TResultPair<S,F>`, a predictable and functional success/failure system.
-- **Pattern Matching:** Use `TMatch<T>` to write expressive code and replace `if-else` chains, in the style of C# or F#.
-- **Simplified Asynchrony:** `TScheduler` brings the power of *async/await* to Delphi, eliminating the complexity of manual threading.
-- **Tuples and Destructuring:** `TTuple<T>` and `TTuple` enable lightweight structures like `(1, 'a')`, with direct value extraction.
-- **Currying:** `TCurrying` introduces partial functions, such as `f(x)(y)`, in the style of Haskell or Scala.
+## 🇬🇧 English
 
-### Compelling Advantages
+**ModernSyntax** is a high-performance, lightweight functional programming and modern syntax extension toolkit for Delphi. 
 
-Why adopt ModernSyntax? Because it transforms Delphi into a competitive tool for modern development without sacrificing what you already love about the language:
+It modernizes Delphi coding paradigms, bringing them on par with features found in advanced contemporary languages like **Rust**, **Kotlin**, **C#**, and **Haskell**. Designed to bridge native Pascal syntax limitations, ModernSyntax introduces safe optional types, functional error flows, advanced pattern matching, asynchronous task scheduling, and currying.
 
-- **Productivity:** Write less boilerplate code with simplified *lambdas*, *list comprehensions*, and *flatmaps*.
-- **Robustness:** Avoid common bugs with *null safety* and explicit error handling.
-- **Maintainability:** Functional and declarative code is easier to understand and update.
-- **Integration:** ModernSyntax seamlessly fits into the Delphi ecosystem, preserving performance and compatibility.
+---
 
-It’s not just a library—it’s an ModernSyntax. With ModernSyntax, you take Delphi beyond its limitations, embracing the best of modern programming while retaining the essence that makes Delphi unique. Try it out and see how your next project can be faster, safer, and more elegant.
+### 🚀 Key Features & Architectural Paradigms
+
+*   **Null Safety (`TOption<T>`):** Prevents common null pointer exceptions. Enforces strict and safe handling of optional values, in the style of Rust or Haskell.
+*   **Functional Error Handling (`TResultPair<S, F>`):** Replaces messy or unpredicted exceptions with a clean, functional success/failure type.
+*   **Pattern Matching (`TMatch<T>`):** Write expressive, type-safe conditional structures. Completely replaces long `if-else` or `case` statements.
+*   **Simplified Asynchrony (`TScheduler`):** Introduces easy *async/await* task scheduling without the overhead of manual thread or task synchronization.
+*   **Tuples & Destructuring (`TTuple<T>`):** Creates lightweight, anonymous data structures (e.g., `(1, 'a', True)`) with direct value extraction.
+*   **Currying (`TCurrying`):** Introduces functional partial application (e.g., `f(x)(y)`), bringing Scala or Haskell paradigms to Delphi.
+
+---
+
+### ⚡️ Quick Start
+
+#### 1. Null Safety (`TOption<T>`)
+```delphi
+uses ModernSyntax.Option;
+
+var
+  LName: TOption<string>;
+begin
+  // Create an optional value that may or may not exist
+  LName := TOption<string>.Some('Isaque');
+  
+  if LName.HasValue then
+    WriteLn('Value: ' + LName.Value)
+  else
+    WriteLn('No value found.');
+    
+  // Default fallback value
+  WriteLn(LName.ValueOrElse('Default Name'));
+end;
+```
+
+#### 2. Pattern Matching (`TMatch<T>`)
+```delphi
+uses ModernSyntax.Match;
+
+var
+  LInput: Integer;
+  LMessage: string;
+begin
+  LInput := 2;
+  
+  // Clean, expressive matching
+  LMessage := TMatch<Integer>.Create(LInput)
+    .CaseOf(1, 'First place!')
+    .CaseOf(2, 'Second place!')
+    .CaseOf(3, 'Third place!')
+    .ElseOf('Runner up.')
+    .MatchValue;
+    
+  // LMessage = 'Second place!'
+end;
+```
+
+#### 3. Functional Results (`TResultPair<S, F>`)
+```delphi
+uses ModernSyntax.ResultPair;
+
+function Divide(const A, B: Double): TResultPair<Double, string>;
+begin
+  if B = 0 then
+    Result := TResultPair<Double, string>.Failure('Division by zero!')
+  else
+    Result := TResultPair<Double, string>.Success(A / B);
+end;
+```
+
+---
+
+### ⛏️ Contributing
+We love contributions! Feel free to open issues or submit pull requests.
+
+### 📬 Contact & Support
+*   **Telegram**: [HashLoad Channel](https://t.me/hashload)
+*   **Website**: [isaquepinheiro.com.br](https://www.isaquepinheiro.com.br)
+
+---
+
+## 🇧🇷 Português
+
+**ModernSyntax** é um kit de ferramentas de alta performance e peso-pena para programação funcional e extensão de sintaxe moderna para Delphi.
+
+Ele moderniza os paradigmas de codificação do Delphi, trazendo-o para o mesmo nível de recursos encontrados em linguagens contemporâneas avançadas como **Rust**, **Kotlin**, **C#** e **Haskell**. Desenvolvido para superar limitações da sintaxe nativa do Pascal, o ModernSyntax introduz tipos opcionais seguros, fluxo de erros funcional, pattern matching avançado, agendamento assíncrono e currying.
+
+---
+
+### 🚀 Recursos Principais & Paradigmas de Arquitetura
+
+*   **Null Safety (`TOption<T>`):** Previne exceções clássicas de ponteiro nulo (Access Violation). Impõe a manipulação estrita e segura de valores opcionais, ao estilo de Rust ou Haskell.
+*   **Tratamento de Erro Funcional (`TResultPair<S, F>`):** Substitui exceções desorganizadas por um tipo limpo e funcional de sucesso/falha.
+*   **Pattern Matching (`TMatch<T>`):** Escreva estruturas condicionais expressivas e fortemente tipadas. Substitui cadeias complexas de `if-else` ou `case` de forma elegante.
+*   **Assincronia Simplificada (`TScheduler`):** Introduz o agendamento de tarefas ao estilo *async/await* sem a complexidade de sincronização manual de threads.
+*   **Tuplas & Desestruturação (`TTuple<T>`):** Cria estruturas leves de dados anônimos (ex: `(1, 'a', True)`) com extração direta de valores.
+*   **Currying (`TCurrying`):** Introduz a aplicação parcial de funções (ex: `f(x)(y)`), trazendo paradigmas do Scala ou Haskell para o Delphi.
+
+---
+
+### ⚡️ Início Rápido
+
+#### 1. Null Safety (`TOption<T>`)
+```delphi
+uses ModernSyntax.Option;
+
+var
+  LName: TOption<string>;
+begin
+  // Cria um valor opcional que pode ou não existir
+  LName := TOption<string>.Some('Isaque');
+  
+  if LName.HasValue then
+    WriteLn('Valor: ' + LName.Value)
+  else
+    WriteLn('Nenhum valor encontrado.');
+    
+  // Valor padrão de fallback caso seja nulo
+  WriteLn(LName.ValueOrElse('Nome Padrão'));
+end;
+```
+
+#### 2. Pattern Matching (`TMatch<T>`)
+```delphi
+uses ModernSyntax.Match;
+
+var
+  LInput: Integer;
+  LMessage: string;
+begin
+  LInput := 2;
+  
+  // Casamento de padrões expressivo e limpo
+  LMessage := TMatch<Integer>.Create(LInput)
+    .CaseOf(1, 'Primeiro lugar!')
+    .CaseOf(2, 'Segundo lugar!')
+    .CaseOf(3, 'Terceiro lugar!')
+    .ElseOf('Participante.')
+    .MatchValue;
+    
+  // LMessage = 'Segundo lugar!'
+end;
+```
+
+#### 3. Resultados Funcionais (`TResultPair<S, F>`)
+```delphi
+uses ModernSyntax.ResultPair;
+
+function Dividir(const A, B: Double): TResultPair<Double, string>;
+begin
+  if B = 0 then
+    Result := TResultPair<Double, string>.Failure('Divisão por zero!')
+  else
+    Result := TResultPair<Double, string>.Success(A / B);
+end;
+```
+
+---
+
+### ⛏️ Contribuição
+Adoramos contribuições! Sinta-se à vontade para abrir issues ou enviar pull requests.
+
+### 📬 Contato & Suporte
+*   **Telegram**: [Canal HashLoad](https://t.me/hashload)
+*   **Website**: [isaquepinheiro.com.br](https://www.isaquepinheiro.com.br)
+
+---
+*Copyright © 2025-2026 Isaque Pinheiro. Licensed under LGPL-3.0 License.*

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ModernSyntax Functional Programming Toolkit for Delphi
 
 [![Delphi XE+](https://img.shields.io/badge/Delphi-XE%20or%20superior-blue.svg)]()
-[![License](https://img.shields.io/badge/License-LGPL--3.0-blue.svg)](LICENSE)
+[![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 *   [🇬🇧 English](#-english)
 *   [🇧🇷 Português](#-português)
@@ -187,4 +187,4 @@ end;
 ```
 
 ---
-*Copyright © 2025-2026 Isaque Pinheiro. Licensed under LGPL-3.0 License.*
+*Copyright © 2025-2026 Isaque Pinheiro. Licensed under MIT License.*


### PR DESCRIPTION
Consolidated, expanded, and modernized the main README.md to be bilingual with English first and Portuguese second. Unified legacy readme files where applicable.