### PR TITLE
fix(async,resultpair): Await(timeout) nao devolve mais sucesso com prazo estourado; Dispose idempotente

### DIFF
--- a/Source/ModernSyntax.Async.pas
+++ b/Source/ModernSyntax.Async.pas
@@ -64,7 +64,29 @@ type
     constructor Create(const AProc: TProc); overload;
     constructor Create(const AFunc: TFunc<TValue>); overload;
   public
+    /// <summary>
+    ///   Waits for the task, then runs <paramref name="AContinue"/> and returns the future.
+    /// </summary>
+    /// <remarks>
+    ///   TIMEOUT SEMANTICS: when <paramref name="ATimeout"/> elapses before the task
+    ///   completes, the returned future is an ERROR (IsErr) whose message states that it
+    ///   was a TIMEOUT and quotes the deadline in milliseconds. The continuation is NOT
+    ///   executed and no success value is published.
+    ///   PRECEDENCE: the timeout wins over a task exception. Once the deadline expires the
+    ///   worker is still running, so its error slot is being written by another thread and
+    ///   cannot be read safely; the future reports the timeout and discards whatever the
+    ///   orphan task may produce later.
+    ///   With the default INFINITE there is no deadline and the behaviour is unchanged.
+    /// </remarks>
     function Await(const AContinue: TProc; const ATimeout: Cardinal = INFINITE): TFuture; overload; inline;
+
+    /// <summary>
+    ///   Waits for the task and returns the future.
+    /// </summary>
+    /// <remarks>
+    ///   Same TIMEOUT semantics and precedence documented in the overload above: an expired
+    ///   deadline yields IsErr with a timeout message, never a success.
+    /// </remarks>
     function Await(const ATimeout: Cardinal = INFINITE): TFuture; overload; inline;
     function Run: TFuture; overload;
     function Run(const AError: TFunc<Exception, TFuture>): TFuture; overload; inline;
@@ -80,6 +102,33 @@ function Async(const AProc: TProc): TAsync; overload; inline;
 function Async(const AFunc: TFunc<TValue>): TAsync; overload; inline;
 
 implementation
+
+resourcestring
+  // Says TIMEOUT out loud and quotes the deadline: whoever debugs a red future has to be
+  // able to tell "the task failed" apart from "the task ran out of time".
+  SAsyncAwaitTimeout = 'Async await TIMEOUT: the task did not complete within %d ms. ' +
+    'The task was not canceled and may still be running; its result and any exception it ' +
+    'raises are discarded.';
+
+/// <summary>
+///   True when the await deadline expired with the task still running.
+/// </summary>
+/// <remarks>
+///   ITask.Wait returns False when it gives up on the deadline and True when the task
+///   finished. That Boolean used to be discarded, so an expired deadline fell straight
+///   through to SetOk and a blown deadline was reported as SUCCESS.
+///   INFINITE means "no deadline": Wait only ever returns after the task completes, and the
+///   extra guard keeps that path provably identical to the previous behaviour.
+/// </remarks>
+function _AwaitTimedOut(const ATask: ITask; const ATimeout: Cardinal): Boolean;
+begin
+  Result := (not ATask.Wait(ATimeout)) and (ATimeout <> INFINITE);
+end;
+
+function _AwaitTimeoutMessage(const ATimeout: Cardinal): String;
+begin
+  Result := Format(SAsyncAwaitTimeout, [ATimeout]);
+end;
 
 function Async(const AProc: TProc): TAsync;
 var
@@ -219,7 +268,15 @@ begin
                                LMessage := E.Message;
                            end;
                          end);
-      FTask.Wait(ATimeout);
+      if _AwaitTimedOut(FTask, ATimeout) then
+      begin
+        // Deadline expired: the worker is still running and still owns LMessage, so reading
+        // it here would be a data race on a half-written value. TIMEOUT therefore takes
+        // precedence over "the task raised", the continuation does not run and nothing is
+        // published as success.
+        Result.SetErr(_AwaitTimeoutMessage(ATimeout));
+        Exit;
+      end;
       if LMessage <> '' then
         raise EAsyncAwait.Create(LMessage);
 
@@ -305,7 +362,14 @@ begin
                                LMessage := E.Message;
                            end;
                          end);
-      FTask.Wait(ATimeout);
+      if _AwaitTimedOut(FTask, ATimeout) then
+      begin
+        // Deadline expired: LValue may never have been assigned (or is being assigned right
+        // now by the worker), so publishing it as a success would hand back a value the task
+        // never produced. TIMEOUT takes precedence and the continuation does not run.
+        Result.SetErr(_AwaitTimeoutMessage(ATimeout));
+        Exit;
+      end;
       if LMessage <> '' then
         raise EAsyncAwait.Create(LMessage);
 
@@ -352,7 +416,13 @@ begin
                                LMessage := E.Message;
                            end;
                          end);
-      FTask.Wait(ATimeout);
+      if _AwaitTimedOut(FTask, ATimeout) then
+      begin
+        // Worst of the four sites before the fix: SetOk(LValue) published an LValue the task
+        // may never have produced. TIMEOUT takes precedence and nothing is published.
+        Result.SetErr(_AwaitTimeoutMessage(ATimeout));
+        Exit;
+      end;
       if LMessage <> '' then
         raise EAsyncAwait.Create(LMessage);
 
@@ -384,7 +454,13 @@ begin
                                LMessage := E.Message;
                            end;
                          end);
-      FTask.Wait(ATimeout);
+      if _AwaitTimedOut(FTask, ATimeout) then
+      begin
+        // Deadline expired with the worker still running: report the TIMEOUT instead of the
+        // old SetOk(True), which claimed the procedure had finished when it had not.
+        Result.SetErr(_AwaitTimeoutMessage(ATimeout));
+        Exit;
+      end;
       if LMessage <> '' then
         raise EAsyncAwait.Create(LMessage);
 

--- a/Source/ModernSyntax.ResultPair.pas
+++ b/Source/ModernSyntax.ResultPair.pas
@@ -149,6 +149,17 @@ type
     ///   Use this procedure to release any resources, if applicable, and perform necessary cleanup
     ///   for the current TResultPair instance. It's recommended to call this method when you are
     ///   finished using the TResultPair object to ensure proper resource management.
+    ///
+    ///   IDEMPOTENT: calling Dispose twice on the same instance frees at most once. The value
+    ///   slot is cleared before the object is freed, so a second call finds nothing to free and
+    ///   returns without touching released memory. It is also safe on a pair whose S/F slot was
+    ///   never set and on a slot holding nil.
+    ///
+    ///   STILL MANUAL BY DESIGN: TResultPair is a plain (unmanaged) record and deliberately has
+    ///   NO class operator Finalize. Going out of scope frees nothing; ownership of any class
+    ///   value stays with the caller. See the note above the implementation of _DestroyFailure
+    ///   for why adding Finalize would be a double-free, both inside this unit and in existing
+    ///   consumers.
     /// </remarks>
     procedure Dispose; inline;
 
@@ -554,16 +565,25 @@ implementation
 procedure TResultPair<S, F>._DestroySuccess;
 var
   LTypeInfo: PTypeInfo;
-  LObject: TValue;
+  LObject: TObject;
 begin
-  if @FSuccess = nil then
-    Exit;
   LTypeInfo := TypeInfo(S);
-  if LTypeInfo.Kind = tkClass then
-  begin
-    LObject := TValue.From<S>(FSuccess.GetValue);
-    LObject.AsObject.Free;
-  end;
+  // `if @FSuccess = nil` (the old guard) can never be True - it is the address of a field of
+  // Self, not a pointer to the value. The guards that actually matter are these three.
+  if LTypeInfo = nil then          // some type arguments carry no RTTI
+    Exit;
+  if LTypeInfo.Kind <> tkClass then // only class values are owned/freed here
+    Exit;
+  // Never set (or already released): nothing to free. Without this, GetValue would raise
+  // 'Value is nil.' whenever S is a class and the pair carries a failure.
+  if not FSuccess.HasValue then
+    Exit;
+  LObject := TValue.From<S>(FSuccess.GetValue).AsObject;
+  // Clear the slot BEFORE freeing. This is what makes Dispose idempotent: a second call (or
+  // a Dispose after some other code already released through this same instance) sees an
+  // empty slot and returns without touching released memory.
+  FSuccess := Default(TResultPairValue<S>);
+  LObject.Free;
 end;
 
 procedure TResultPair<S, F>._SetFailureValue(const AFailure: F);
@@ -589,19 +609,51 @@ begin
   _DestroyFailure;
 end;
 
+// WHY THERE IS NO `class operator Finalize` HERE
+// ----------------------------------------------
+// The obvious "structural" fix for the leak of a class-typed failure value would be to give
+// TResultPair a Finalize operator so that leaving scope releases it. It cannot be done in
+// this shape, and it would be strictly worse than the leak:
+//
+//  1) The record is copied on almost every call. Success/Failure/Pure/Ok/Fail/When/Map/
+//     ThenOf/ExceptOf/Return all do `Result := Self`, and Reduce/_ReturnSuccess/_ReturnFailure
+//     keep local copies. Every one of those temporaries holds the SAME object pointer, so a
+//     Finalize that frees would double-free inside this very unit, before any consumer code
+//     is reached. Making it correct would require a full ownership model (class operator
+//     Assign + a heap-allocated refcount), which changes copy semantics and cost for everyone.
+//
+//  2) Consumers already free manually. In the ERP that drives this framework there are ~9
+//     call sites that read the failure and free it, plus ~1128 `procedure(E: Exception)`
+//     callbacks whose body is `E.Free`. Turning the record managed converts every one of them
+//     into a double free - heap corruption instead of a leak.
+//
+//  3) A consumer test asserts the current semantics on purpose ("leaving scope does NOT
+//     release, which is why the consume-helper exists"). Finalize would both fail that test
+//     and crash it.
+//
+//  4) Custom managed records (Initialize/Finalize/Assign) require Delphi 10.4+; this unit is
+//     built for the compatibility matrix in ModernSyntax.inc (Delphi 2010 upwards) and for
+//     FPC/Lazarus. Adding them would drop compilers that work today.
+//
+// So ownership stays explicit: Dispose is the single, MANUAL release point - and it is now
+// idempotent, so calling it twice (or after someone else already released through the same
+// instance) is harmless.
 procedure TResultPair<S, F>._DestroyFailure;
 var
   LTypeInfo: PTypeInfo;
-  LObject: TValue;
+  LObject: TObject;
 begin
-  if @FFailure = nil then
-    Exit;
   LTypeInfo := TypeInfo(F);
-  if LTypeInfo.Kind = tkClass then
-  begin
-    LObject := TValue.From<F>(FFailure.GetValue);
-    LObject.AsObject.Free;
-  end;
+  if LTypeInfo = nil then
+    Exit;
+  if LTypeInfo.Kind <> tkClass then
+    Exit;
+  if not FFailure.HasValue then
+    Exit;
+  LObject := TValue.From<F>(FFailure.GetValue).AsObject;
+  // Clear before freeing - see _DestroySuccess.
+  FFailure := Default(TResultPairValue<F>);
+  LObject.Free;
 end;
 
 function TResultPair<S, F>.Fail(const AFailureProc: TProc<F>): TResultPair<S, F>;

--- a/Test Delphi/EclbrResultPair/UTestMS.ResultPair.pas
+++ b/Test Delphi/EclbrResultPair/UTestMS.ResultPair.pas
@@ -62,6 +62,21 @@ type
     procedure TestValueSuccessNil;
     [Test]
     procedure TestValueSuccessNilSetFailure;
+    // --- Dispose: idempotent, nil-safe and explicitly NOT automatic ---
+    [Test]
+    procedure TestDisposeFailureTwiceFreesOnlyOnce;
+    [Test]
+    procedure TestDisposeSuccessTwiceFreesOnlyOnce;
+    [Test]
+    procedure TestDisposeOnUnsetSlotDoesNotRaise;
+    [Test]
+    procedure TestDisposeOnNilObjectIsSafe;
+    [Test]
+    procedure TestDisposeLeavesNonClassValuesUntouched;
+    [Test]
+    procedure TestCopyingAndImplicitFreeNothingByThemselves;
+    [Test]
+    procedure TestLeavingScopeDoesNotFree;
   end;
 
 implementation
@@ -85,7 +100,7 @@ end;
 
 procedure TTestTResultPair.TearDown;
 begin
-  // Não precisa de Dispose, liberação é automática
+  // Nï¿½o precisa de Dispose, liberaï¿½ï¿½o ï¿½ automï¿½tica
 end;
 
 procedure TTestTResultPair.TestFailure;
@@ -346,6 +361,199 @@ begin
   Result.Success(nil);
   if Result.ValueSuccess = nil then
     Exit;
+end;
+
+{ Dispose
+
+  TResultPair owns nothing automatically: it is a plain record with NO class operator
+  Finalize, so a class-typed Success/Failure value is released only by an explicit Dispose.
+  That is deliberate - see the long note above _DestroyFailure in
+  Source\ModernSyntax.ResultPair.pas - and these tests pin both halves of the contract:
+
+    * Dispose is IDEMPOTENT and nil-safe: calling it twice on the same instance, on a slot
+      that was never set, or on a slot holding nil, frees at most once and never raises;
+    * copying (including through the Implicit operators) frees NOTHING by itself, and
+      leaving scope frees NOTHING - which is exactly what consumers that already release
+      the failure by hand depend on.
+
+  LIMIT, stated out loud: idempotency is PER INSTANCE. Two separate copies of the same pair
+  each holding the same object pointer will free it twice if Dispose is called on both -
+  the same way calling Free on two variables pointing at one object does. Ownership is
+  manual: one owner, one Dispose. }
+
+type
+  // The only way to prove a release is to count destructions.
+  TSpyObject = class
+  public
+    destructor Destroy; override;
+  end;
+
+var
+  GSpyDestroyed: Integer = 0;
+
+destructor TSpyObject.Destroy;
+begin
+  Inc(GSpyDestroyed);
+  inherited;
+end;
+
+procedure TTestTResultPair.TestDisposeFailureTwiceFreesOnlyOnce;
+var
+  LPair: TResultPair<String, TSpyObject>;
+  LBefore: Integer;
+begin
+  LBefore := GSpyDestroyed;
+  LPair := TResultPair<String, TSpyObject>.New.Failure(TSpyObject.Create);
+
+  LPair.Dispose;
+  Assert.AreEqual(LBefore + 1, GSpyDestroyed, 'the first Dispose releases the failure object');
+
+  LPair.Dispose;
+  Assert.AreEqual(LBefore + 1, GSpyDestroyed,
+    'the second Dispose is a no-op - the slot was cleared BEFORE the object was freed, so ' +
+    'nothing touches released memory and there is no double free');
+
+  // Fail-fast side effect of clearing the slot: reading the value after Dispose raises
+  // instead of handing back a dangling pointer.
+  Assert.WillRaise(
+    procedure
+    begin
+      LPair.ValueFailure;
+    end,
+    Exception,
+    'after Dispose the slot is empty, not dangling');
+end;
+
+procedure TTestTResultPair.TestDisposeSuccessTwiceFreesOnlyOnce;
+var
+  LPair: TResultPair<TSpyObject, String>;
+  LBefore: Integer;
+begin
+  LBefore := GSpyDestroyed;
+  LPair := TResultPair<TSpyObject, String>.New.Success(TSpyObject.Create);
+
+  LPair.Dispose;
+  Assert.AreEqual(LBefore + 1, GSpyDestroyed, 'the first Dispose releases the success object');
+
+  LPair.Dispose;
+  Assert.AreEqual(LBefore + 1, GSpyDestroyed, 'the second Dispose frees nothing again');
+end;
+
+procedure TTestTResultPair.TestDisposeOnUnsetSlotDoesNotRaise;
+var
+  LBefore: Integer;
+begin
+  // Regression: _DestroySuccess used to call GetValue unconditionally, so Dispose on a pair
+  // whose S is a class and whose SUCCESS slot was never filled raised 'Value is nil.'.
+  // A cleanup routine must never be the thing that blows up.
+  LBefore := GSpyDestroyed;
+  Assert.WillNotRaise(
+    procedure
+    var
+      LPair: TResultPair<TSpyObject, String>;
+    begin
+      LPair := TResultPair<TSpyObject, String>.New.Failure('no object was ever set');
+      LPair.Dispose;
+    end,
+    Exception,
+    'Dispose on an unset class slot is a no-op, not an error');
+  Assert.AreEqual(LBefore, GSpyDestroyed, 'and nothing was released');
+end;
+
+procedure TTestTResultPair.TestDisposeOnNilObjectIsSafe;
+var
+  LPair: TResultPair<String, TSpyObject>;
+  LBefore: Integer;
+begin
+  LBefore := GSpyDestroyed;
+  LPair := TResultPair<String, TSpyObject>.New.Failure(nil);
+  Assert.WillNotRaise(
+    procedure
+    begin
+      LPair.Dispose;
+      LPair.Dispose;
+    end,
+    Exception,
+    'a slot explicitly holding nil survives Dispose, twice');
+  Assert.AreEqual(LBefore, GSpyDestroyed, 'nil is nothing to release');
+end;
+
+procedure TTestTResultPair.TestDisposeLeavesNonClassValuesUntouched;
+var
+  LPair: TResultPair<String, TSpyObject>;
+  LBefore: Integer;
+begin
+  // Dispose only ever touches CLASS slots: a string success value comes out intact.
+  LBefore := GSpyDestroyed;
+  LPair := TResultPair<String, TSpyObject>.New.Success('payload');
+
+  LPair.Dispose;
+
+  Assert.IsTrue(LPair.isSuccess, 'the result is still a success after Dispose');
+  Assert.AreEqual('payload', LPair.ValueSuccess, 'and the success value is untouched');
+  Assert.AreEqual(LBefore, GSpyDestroyed, 'nothing was released - there was no object');
+end;
+
+procedure TTestTResultPair.TestCopyingAndImplicitFreeNothingByThemselves;
+var
+  LPair: TResultPair<String, TSpyObject>;
+  LCopy: TResultPair<String, TSpyObject>;
+  LFromSlot: TResultPair<String, TSpyObject>;
+  LSuccessSlot: TResultPairValue<String>;
+  LFailureSlot: TResultPairValue<TSpyObject>;
+  LBefore: Integer;
+begin
+  LBefore := GSpyDestroyed;
+  LPair := TResultPair<String, TSpyObject>.New.Failure(TSpyObject.Create);
+
+  // Plain copy, both Implicit directions, and the comparison operators (which take the
+  // record by const and therefore copy nothing they can destroy).
+  LCopy := LPair;
+  LSuccessSlot := LPair;
+  LFailureSlot := LPair;
+  LFromSlot := LFailureSlot;
+  Assert.IsFalse(LSuccessSlot.HasValue, 'the success slot of a failure pair carries no value');
+  Assert.IsTrue(LFailureSlot.HasValue, 'the failure slot travels through Implicit');
+  Assert.IsTrue(LFromSlot.ValueFailure = LPair.ValueFailure,
+    'Implicit round-trip yields the same object, it does not clone or release it');
+
+  Assert.AreEqual(LBefore, GSpyDestroyed,
+    'the record is NOT managed: copying and Implicit release nothing, so no copy can turn ' +
+    'into a double free on its own');
+
+  // One owner, one Dispose - and it is LPair. LCopy/LFromSlot are aliases of the same
+  // object and are deliberately NOT disposed here (see the LIMIT note above).
+  LPair.Dispose;
+  Assert.AreEqual(LBefore + 1, GSpyDestroyed, 'the single owner releases it exactly once');
+end;
+
+procedure TTestTResultPair.TestLeavingScopeDoesNotFree;
+var
+  LSpy: TSpyObject;
+  LBefore: Integer;
+
+  procedure _Scope;
+  var
+    LPair: TResultPair<String, TSpyObject>;
+  begin
+    LPair := TResultPair<String, TSpyObject>.New.Failure(LSpy);
+    Assert.IsTrue(LPair.isFailure, 'failure pair built inside the scope');
+  end;
+
+begin
+  // Contract lock: adding a class operator Finalize would make this pass silently while
+  // double-freeing every consumer that already releases the failure by hand (and every
+  // intermediate `Result := Self` copy inside the unit itself). The reference is kept
+  // OUTSIDE the scope precisely because the record does not release it.
+  LSpy := TSpyObject.Create;
+  LBefore := GSpyDestroyed;
+
+  _Scope;
+
+  Assert.AreEqual(LBefore, GSpyDestroyed,
+    'leaving scope releases NOTHING - ownership stays with the caller, on purpose');
+  LSpy.Free;
+  Assert.AreEqual(LBefore + 1, GSpyDestroyed, 'the caller is the one who releases it');
 end;
 
 initialization

--- a/Test Delphi/EclbrSystem/UTestMMS.Threading.pas
+++ b/Test Delphi/EclbrSystem/UTestMMS.Threading.pas
@@ -8,6 +8,7 @@ uses
   SysUtils,
   DateUtils,
   Classes,
+  SyncObjs,
   Generics.Collections,
   ModernSyntax.Async,
   ModernSyntax;
@@ -36,6 +37,21 @@ type
     procedure TestAwaitFuture;
     [Test]
     procedure TestFetchAsyncAwait;
+    // --- Await(timeout): an expired deadline must be an ERROR, never a success ---
+    [Test]
+    procedure TestAwaitProcTimeoutFails;
+    [Test]
+    procedure TestAwaitFuncTimeoutPublishesNoValue;
+    [Test]
+    procedure TestAwaitTimeoutDoesNotRunContinuation;
+    [Test]
+    procedure TestAwaitWithinDeadlineSucceeds;
+    [Test]
+    procedure TestAwaitInfiniteIsUnchanged;
+    [Test]
+    procedure TestAwaitTaskExceptionKeepsItsMessage;
+    [Test]
+    procedure TestAwaitTaskExceptionWinsWhenTaskFinishedInTime;
   end;
 
 implementation
@@ -149,9 +165,9 @@ var
   LFuture: TFuture;
   LErr: String;
 begin
-  // Neste caso no ECL o "Run" não usa Function, mas somente Procedure, se quiser
+  // Neste caso no ECL o "Run" nï¿½o usa Function, mas somente Procedure, se quiser
   // usar Function use o "Await", pois ele espera o resultado para devolver, o
-  // "Run" não fica esperando, somente aloca a thread e executa
+  // "Run" nï¿½o fica esperando, somente aloca a thread e executa
   LFuture := Async(function: TValue
                    begin
                      Result := False;
@@ -161,6 +177,185 @@ begin
   Assert.IsTrue(LFuture.IsErr);
   LErr := 'The "Run" method should not be invoked as a function. Utilize the "Await" method to wait for task completion and access the result, or invoke it as a procedure.';
   Assert.AreEqual(LErr, LFuture.Err);
+end;
+
+{ Await(timeout)
+
+  Until this fix, FTask.Wait(ATimeout) had its Boolean result DISCARDED at the four await
+  sites, so execution fell straight through to Result.SetOk(...): a blown deadline was
+  reported as SUCCESS, and in the TFunc overload it even published an LValue the task might
+  never have produced.
+
+  DETERMINISM (no machine-speed dependency, on purpose):
+    * the "must time out" tests run a task that sleeps CTaskSleepMs and wait only
+      CDeadlineMs. Sleep never returns EARLY, so the task physically cannot finish inside the
+      deadline - a slow machine only makes the gap bigger. There is no flake window;
+    * the "must succeed" tests use CGenerousMs, three orders of magnitude above the work;
+    * after a timeout the orphan task keeps running (Await does not cancel it). Each timeout
+      test drains it with Sleep(CDrainMs) before returning, so no stray task survives into
+      the next test. }
+
+const
+  CTaskSleepMs = 300;   // task work: ALWAYS longer than the deadline below
+  CDeadlineMs  = 60;    // deadline: ALWAYS shorter than the task work above
+  CDrainMs     = 600;   // > CTaskSleepMs: lets the orphaned task finish before we return
+  CGenerousMs  = 30000; // deadline a trivial task cannot miss
+
+procedure TTesTStd.TestAwaitProcTimeoutFails;
+var
+  LAsync: TAsync;
+  LFuture: TFuture;
+begin
+  LAsync := Async(procedure
+                  begin
+                    Sleep(CTaskSleepMs);
+                  end);
+  LFuture := LAsync.Await(CDeadlineMs);
+  try
+    Assert.IsTrue(LFuture.IsErr, 'an expired deadline is an ERROR');
+    Assert.IsFalse(LFuture.IsOk, 'and it must NOT be reported as a success');
+    Assert.IsTrue(Pos('TIMEOUT', LFuture.Err) > 0,
+      'the message has to say TIMEOUT so it can be told apart from "the task failed": ' +
+      LFuture.Err);
+    Assert.IsTrue(Pos(IntToStr(CDeadlineMs) + ' ms', LFuture.Err) > 0,
+      'the message has to quote the deadline that was blown: ' + LFuture.Err);
+  finally
+    Sleep(CDrainMs);
+  end;
+end;
+
+procedure TTesTStd.TestAwaitFuncTimeoutPublishesNoValue;
+var
+  LAsync: TAsync;
+  LFuture: TFuture;
+begin
+  // The nastiest of the four sites: SetOk(LValue) used to publish a value the task had not
+  // produced yet. Now nothing at all is published.
+  LAsync := Async(function: TValue
+                  begin
+                    Sleep(CTaskSleepMs);
+                    Result := 'never delivered';
+                  end);
+  LFuture := LAsync.Await(CDeadlineMs);
+  try
+    Assert.IsTrue(LFuture.IsErr, 'an expired deadline is an ERROR');
+    Assert.IsTrue(Pos('TIMEOUT', LFuture.Err) > 0, 'and it says TIMEOUT: ' + LFuture.Err);
+    Assert.WillRaise(
+      procedure
+      begin
+        LFuture.Ok<String>;
+      end,
+      Exception,
+      'no success value may be readable after a timeout');
+  finally
+    Sleep(CDrainMs);
+  end;
+end;
+
+procedure TTesTStd.TestAwaitTimeoutDoesNotRunContinuation;
+var
+  LAsync: TAsync;
+  LFuture: TFuture;
+  LContinue: Boolean;
+begin
+  LContinue := False;
+  LAsync := Async(function: TValue
+                  begin
+                    Sleep(CTaskSleepMs);
+                    Result := 'never delivered';
+                  end);
+  LFuture := LAsync.Await(procedure
+                          begin
+                            LContinue := True;
+                          end,
+                          CDeadlineMs);
+  try
+    Assert.IsTrue(LFuture.IsErr, 'an expired deadline is an ERROR');
+    Assert.IsFalse(LContinue,
+      'the continuation belongs to a COMPLETED task - it must not run after a timeout');
+  finally
+    Sleep(CDrainMs);
+  end;
+end;
+
+procedure TTesTStd.TestAwaitWithinDeadlineSucceeds;
+var
+  LFuture: TFuture;
+begin
+  // A deadline that is comfortably met must behave exactly like before the fix.
+  LFuture := Async(function: TValue
+                   begin
+                     Result := 'inside the deadline';
+                   end)
+            .Await(CGenerousMs);
+
+  Assert.IsTrue(LFuture.IsOk, 'a task that finishes in time still succeeds');
+  Assert.IsFalse(LFuture.IsErr, 'and carries no error');
+  Assert.AreEqual('inside the deadline', LFuture.Ok<String>);
+end;
+
+procedure TTesTStd.TestAwaitInfiniteIsUnchanged;
+var
+  LProcFuture: TFuture;
+  LFuncFuture: TFuture;
+  LExecuted: Boolean;
+begin
+  // INFINITE is the DEFAULT of the parameter: this is the path every existing caller takes,
+  // and it must keep waiting forever and succeeding, no matter how long the task takes.
+  LExecuted := False;
+  LProcFuture := Async(procedure
+                       begin
+                         Sleep(CTaskSleepMs);
+                         LExecuted := True;
+                       end)
+                .Await;
+  Assert.IsTrue(LProcFuture.IsOk, 'INFINITE waits for the procedure, however long it takes');
+  Assert.IsTrue(LProcFuture.Ok<Boolean>);
+  Assert.IsTrue(LExecuted, 'the procedure really ran to completion');
+
+  LFuncFuture := Async(function: TValue
+                       begin
+                         Sleep(CTaskSleepMs);
+                         Result := 'waited it out';
+                       end)
+                .Await(INFINITE);
+  Assert.IsTrue(LFuncFuture.IsOk, 'explicit INFINITE behaves the same as the default');
+  Assert.AreEqual('waited it out', LFuncFuture.Ok<String>);
+end;
+
+procedure TTesTStd.TestAwaitTaskExceptionKeepsItsMessage;
+var
+  LFuture: TFuture;
+begin
+  // Unchanged semantics: a task that raises turns into an error carrying ITS message.
+  LFuture := Async(function: TValue
+                   begin
+                     raise Exception.Create('task blew up');
+                   end)
+            .Await;
+
+  Assert.IsTrue(LFuture.IsErr, 'a task that raises produces an error future');
+  Assert.AreEqual('task blew up', LFuture.Err, 'the task message is preserved verbatim');
+  Assert.IsTrue(Pos('TIMEOUT', LFuture.Err) = 0, 'a failure is not a timeout');
+end;
+
+procedure TTesTStd.TestAwaitTaskExceptionWinsWhenTaskFinishedInTime;
+var
+  LFuture: TFuture;
+begin
+  // PRECEDENCE, documented side: the task finished (by raising) inside the deadline, so the
+  // future reports the TASK's failure, not a timeout. The other side of the rule - deadline
+  // expired first - is covered above: there the worker is still running and its message
+  // cannot be read without a data race, so TIMEOUT wins.
+  LFuture := Async(procedure
+                   begin
+                     raise Exception.Create('failed fast');
+                   end)
+            .Await(CGenerousMs);
+
+  Assert.IsTrue(LFuture.IsErr);
+  Assert.AreEqual('failed fast', LFuture.Err,
+    'the task failed within the deadline: its own message is what surfaces');
 end;
 
 initialization


### PR DESCRIPTION
## O que quebrava

**FIX 1 - `Await(timeout)` devolvia SUCESSO com o prazo estourado** (`Source/ModernSyntax.Async.pas`)

`FTask.Wait(ATimeout)` devolve `Boolean` (True = concluiu, False = estourou o prazo) e o retorno era **descartado** nos 4 pontos de await (`:222`, `:308`, `:355`, `:387` no codigo antigo). O fluxo caia direto no `Result.SetOk(...)`. Pior no overload de `TFunc`, onde `SetOk(LValue)` publicava um `LValue` que a tarefa podia nem ter produzido.

**FIX 2 - `TResultPair.Dispose` nao era idempotente** (`Source/ModernSyntax.ResultPair.pas`)

Chamar `Dispose` duas vezes na mesma instancia era **double free**. E `Dispose` num par cujo `S` e classe e cujo slot de sucesso nunca foi setado **levantava** `'Value is nil.'` - rotina de limpeza nao pode ser a coisa que explode. A guarda `if @FSuccess = nil` nunca era verdadeira (e o endereco de um campo de `Self`, nao um ponteiro para o valor).

## O que mudou

### Fix 1
`_AwaitTimedOut` captura o Boolean; prazo estourado devolve `SetErr` com mensagem que **diz TIMEOUT e cita o prazo em ms**. A continuacao nao roda e nada e publicado como sucesso.

- **`INFINITE` provadamente intacto**: `_AwaitTimedOut` so acusa timeout quando `ATimeout <> INFINITE`. O caminho sem prazo - o default do parametro, que e o que todo chamador existente usa - segue exatamente como antes.
- **Precedencia definida e documentada na interface**: o **TIMEOUT vence** a excecao da tarefa. Quando o prazo estoura, o worker ainda esta rodando e ainda e dono de `LMessage`/`LValue`; le-los ali seria data race sobre valor meio-escrito. Quando a tarefa termina (inclusive levantando) **dentro** do prazo, a mensagem dela e a que sai - semantica inalterada.

### Fix 2 - opcao CONSERVADORA, escolhida de proposito
`_DestroySuccess`/`_DestroyFailure` limpam o slot **antes** de liberar o objeto e checam `HasValue`/nil/RTTI. `Dispose` fica idempotente e nil-safe.

**NAO foi adicionado `class operator Finalize`.** Justificativa completa no codigo (nota acima de `_DestroyFailure`):

1. O record e copiado em quase toda chamada - `Result := Self` em `Success`/`Failure`/`Pure`/`Ok`/`Fail`/`When`/`Map`/`ThenOf`/`ExceptOf`/`Return`, mais as copias locais em `_ReturnSuccess`/`_ReturnFailure`. Cada temporario carrega o **mesmo ponteiro**: um `Finalize` que libera daria double free **dentro da propria unit**, antes de chegar em qualquer consumidor. Corrigir isso exigiria modelo de posse completo (`class operator Assign` + refcount no heap), mudando semantica e custo de copia para todo mundo.
2. Consumidores **ja liberam a mao**: no ERP que dirige este framework sao ~9 call sites que consomem e liberam a falha, mais ~1128 callbacks `procedure(E: Exception)` cujo corpo e `E.Free`. Tornar o record gerenciado converte cada um deles em double free.
3. Um teste de consumidor **trava a semantica atual** de proposito ("sair de escopo NAO libera, e por isso o helper de consumo existe"). `Finalize` reprovaria esse teste **e** o derrubaria.
4. Records gerenciados (`Initialize`/`Finalize`/`Assign`) exigem Delphi 10.4+; esta unit atende a matriz do `ModernSyntax.inc` (Delphi 2010 pra cima) e o alvo FPC/Lazarus.

Vazamento consome memoria; double free corrompe heap e derruba servidor. A propriedade ganha aqui e **idempotencia**, nao automatismo - e a posse continua explicita: um dono, um `Dispose`.

## Testes

**+7 em `UTestMMS.Threading.pas`** - prazo estourado da erro com "TIMEOUT" e o prazo na mensagem; o valor nao fica legivel; a continuacao nao roda; tarefa dentro do prazo tem sucesso; `INFINITE` inalterado (proc e func); tarefa que levanta mantem a mensagem dela.

**Determinismo por construcao, nao por sorte**: a tarefa dorme 300 ms e o prazo e 60 ms - `Sleep` nunca retorna **antes** do tempo, entao maquina lenta so **aumenta** a folga; nao existe janela de flake. Os testes de sucesso usam prazo de 30 s. Cada teste de timeout drena a tarefa orfa antes de retornar (o `Await` nao cancela a tarefa).

**+7 em `UTestMS.ResultPair.pas`** - `Dispose` duplo libera uma vez so (falha e sucesso); slot nunca setado nao levanta; slot com nil e seguro; valor nao-classe fica intacto; copia e `Implicit` nao liberam nada sozinhos; e **sair de escopo NAO libera** (trava o contrato contra alguem adicionar `Finalize` depois).

**Contraprova**: com o `Source` pre-fix, 3 dos novos testes de `Await` falham, e os de `ResultPair` acusam `Invalid pointer operation` (o double free) e `Value is nil.`.

## Gate

| Suite | Resultado |
|---|---|
| `PTestAsync` (ModernSyntax) | **14/14** (7 antigos + 7 novos) |
| `PTestResultPair` (ModernSyntax) | **27/27** (20 antigos + 7 novos) |
| Compilacao de todas as units de `Source` | Win32 **OK**, Win64 **OK** |
| As 2 units alteradas em `dcclinux64` | **OK** |
| Consumidor real (ERP Axial) | **5078/5078 verde**, zero double free |

Delphi 12 Athens (compilador 36.0). O consumidor real exercita ~1128 callbacks que liberam a excecao e 9 pontos de consumo de falha - inclusive a suite que testa exatamente o dispose - e nenhum deles mudou de comportamento.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VXNEDRiAp1tpyF2Ffw3QiP
