### PR TITLE
docs(resultpair,async): record the Return KNOWN BUG, correct the false claim from #7, restore lost accents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,116 @@
+# Changelog
+
+All notable changes to **ModernSyntax** are documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
+aims at [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+This file starts at `v1.2.0`; for anything older, read the git history.
+
+---
+
+## [Unreleased]
+
+### ⚠️ BREAKING — `Await(timeout)` no longer reports success on a blown deadline
+
+Merged in [#7](https://github.com/ModernDelphiWorks/ModernSyntax/pull/7).
+
+`TAsync.Await` discarded the `Boolean` returned by `ITask.Wait(ATimeout)` at all four await
+sites, so an expired deadline fell through to `Result.SetOk(...)`. A blown deadline was
+reported as **SUCCESS**, and the `TFunc` overload even published an `LValue` the task might
+never have produced. Now an expired deadline yields `IsErr` with a message that says `TIMEOUT`
+and quotes the deadline in ms; the continuation does not run and nothing is published.
+
+**Who breaks:** anyone who called `Await(timeout)` with a *finite* deadline and treated the
+result as "fire and forget with a grace period" — i.e. code that read `IsOk` after the
+deadline and carried on. That code used to see `IsOk = True` for work that had not finished;
+it now sees `IsErr = True`. Any branch keyed on `IsOk` inverts.
+
+**Who does not break:** `Await` and `Await(INFINITE)` — the parameter default — are provably
+unchanged. `_AwaitTimedOut` only reports a timeout when `ATimeout <> INFINITE`, so the
+no-deadline path is byte-for-byte the old behaviour. This is the path every pre-existing
+caller who never passed a deadline is on.
+
+**Migration:**
+
+```pascal
+// before - "success" could mean "still running"
+LFuture := LAsync.Await(500);
+if LFuture.IsOk then
+  ...
+
+// after - decide explicitly what a blown deadline means
+LFuture := LAsync.Await(500);
+if LFuture.IsOk then
+  ...                        // really finished
+else if IsAwaitTimeout(LFuture) then
+  ...                        // deadline blown, task still running
+else
+  ...                        // the task itself failed: LFuture.Err
+```
+
+To keep the old "no deadline" semantics, drop the argument: `LAsync.Await`.
+
+### Added
+
+- `ModernSyntax.Async.IsAwaitTimeout(const AFuture: TFuture): Boolean` — the supported way to
+  tell a blown `Await` deadline from a task failure. Replaces `Pos('TIMEOUT', LFuture.Err)`,
+  which breaks on a reworded message and misfires on task messages that merely contain the
+  word. The check is anchored at the start of the message.
+
+### Changed
+
+- The `Await` timeout message is now a **frozen contract**, declared as a `const` instead of a
+  `resourcestring` so that translation tooling cannot silently patch it. Its ASCII prefix
+  (`Async await TIMEOUT:`) must not be reworded or localized; the tail after the prefix may be
+  improved. Rationale, including why `TFuture` did **not** get a discriminator field, is
+  documented above the constant in `Source/ModernSyntax.Async.pas`.
+- `TAsync.Await` `<remarks>` now document that a timeout does **not** cancel the task and that
+  the orphan keeps dereferencing `@Self`, so with a finite deadline the `TAsync` must be held
+  in a named variable rather than awaited as a temporary (`Async(...).Await(50)`).
+- `TResultPair.Dispose` `<remarks>` now state that idempotence is **per instance, not per
+  object**: two copies of the record hold the same pointer, so two copies with one `Dispose`
+  each still free twice.
+- Corrected the "why there is no `class operator Finalize`" note in
+  `Source/ModernSyntax.ResultPair.pas`: it cited `ModernSyntax.inc`, a Delphi 2010 floor and an
+  FPC/Lazarus target, none of which hold. The unit does not include the `.inc`, no unit in the
+  repository consumes any symbol it defines, the declared floor is Delphi XE (`README.md:3`,
+  `README.md:33`), and the `.inc`'s Lazarus block is dead code guarded by a typo (`FCP`). The
+  decision itself is unchanged and still correct: managed records need 10.4+, which is above
+  the XE floor.
+
+### Fixed
+
+- Restored the accented characters in two test files that were mangled to `U+FFFD` by an
+  encoding change in #7: `Test Delphi/EclbrResultPair/UTestMS.ResultPair.pas` and
+  `Test Delphi/EclbrSystem/UTestMMS.Threading.pas`. Both are back to the repository's CP1252,
+  no-BOM convention for accented Pascal sources.
+
+### Documented (not fixed)
+
+- `KNOWN BUG` markers on `TResultPair._ReturnSuccess` / `_ReturnFailure`, tracked by
+  [#8](https://github.com/ModernDelphiWorks/ModernSyntax/issues/8): the `Return` chain discards
+  the transformation (`Result := Self` is taken before the loop mutates `Self`), does not
+  compose across steps, and leaves a dangling pointer (`_Set*Value` adopts a pointer that the
+  following `LResult.Dispose` frees). For `TResultPair<class, class>` #7 changed how it shows
+  up: it used to abort loudly with `'Value is nil.'`, it is now a silent use-after-free. The
+  fix is an ownership refactor of the chain and belongs in its own PR.
+
+---
+
+## [1.2.0] - 2026-06-20
+
+### Fixed
+
+- `dcclinux64` E2076: `TResultPair<>.Failure` / `.Success` were being called as class methods;
+  changed to `.New.Failure` / `.New.Success` in `ModernSyntax.Match` and `ModernSyntax.Option`.
+
+### Added
+
+- Cross-platform build verified on Win32, Win64 and Linux64 (`dcclinux64`): POSIX
+  `setenv`/`unsetenv` shim for `TDotEnv`, `stderr` fallback for `OutputDebugString`,
+  `AtomicIncrement` in place of `InterlockedIncrement64`, and `{$IFDEF MSWINDOWS}` guards on
+  bare `uses Windows` clauses.
+
+[Unreleased]: https://github.com/ModernDelphiWorks/ModernSyntax/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/ModernDelphiWorks/ModernSyntax/releases/tag/v1.2.0

--- a/Source/ModernSyntax.Async.pas
+++ b/Source/ModernSyntax.Async.pas
@@ -77,6 +77,28 @@ type
     ///   cannot be read safely; the future reports the timeout and discards whatever the
     ///   orphan task may produce later.
     ///   With the default INFINITE there is no deadline and the behaviour is unchanged.
+    ///
+    ///   THE ORPHAN TASK OUTLIVES THE AWAIT - KEEP THE TAsync ALIVE. A timeout does not cancel
+    ///   anything: the worker keeps running, and it holds LSelf := @Self, a RAW POINTER to this
+    ///   record (ModernSyntax.Async.pas:258, :352, :406 and :444), which it dereferences to
+    ///   reach FProc/FFunc. If the TAsync was a temporary, its storage is gone the moment the
+    ///   expression ends and the orphan dereferences dead memory. So with a FINITE deadline the
+    ///   fluent form is unsafe:
+    ///
+    ///     LFuture := Async(LWork).Await(50);   // WRONG: the TAsync is a temporary
+    ///
+    ///     LAsync  := Async(LWork);             // RIGHT: named variable, outlives the orphan
+    ///     LFuture := LAsync.Await(50);
+    ///     // ...and keep LAsync in scope until LAsync.Status is Completed/Exception, or the
+    ///     // work is otherwise known to have finished.
+    ///
+    ///   The lifetime hazard is older than the timeout support, but it used to be unreachable
+    ///   in practice: with INFINITE the await only returns after the task is done, so the
+    ///   record is never released early. Finite deadlines - and the timeout/retry style they
+    ///   invite - are what make the orphan a real exposure.
+    ///
+    ///   USE IsAwaitTimeout(LFuture) to tell a blown deadline from a task failure; do not
+    ///   pattern-match the message text yourself.
     /// </remarks>
     function Await(const AContinue: TProc; const ATimeout: Cardinal = INFINITE): TFuture; overload; inline;
 
@@ -86,6 +108,9 @@ type
     /// <remarks>
     ///   Same TIMEOUT semantics and precedence documented in the overload above: an expired
     ///   deadline yields IsErr with a timeout message, never a success.
+    ///   The same lifetime rule applies: with a finite deadline the orphan task keeps
+    ///   dereferencing @Self, so hold the TAsync in a named variable instead of awaiting a
+    ///   temporary. Use IsAwaitTimeout to classify the result.
     /// </remarks>
     function Await(const ATimeout: Cardinal = INFINITE): TFuture; overload; inline;
     function Run: TFuture; overload;
@@ -101,12 +126,52 @@ type
 function Async(const AProc: TProc): TAsync; overload; inline;
 function Async(const AFunc: TFunc<TValue>): TAsync; overload; inline;
 
+/// <summary>
+///   True when <paramref name="AFuture"/> is the error produced by an Await deadline that
+///   expired, as opposed to an error produced by the task itself.
+/// </summary>
+/// <remarks>
+///   THE ONE SUPPORTED WAY TO CLASSIFY A RED FUTURE. Before this existed the only way to tell
+///   a blown deadline from a task failure was Pos('TIMEOUT', LFuture.Err) over the message -
+///   which silently breaks the day the message is reworded, and misfires whenever a task's own
+///   exception happens to contain the word.
+///   Returns False for a successful future, for an empty error, and for any error the task
+///   raised. See the note on the timeout message in the implementation for why the text is
+///   frozen instead of TFuture carrying a discriminator field.
+/// </remarks>
+function IsAwaitTimeout(const AFuture: TFuture): Boolean;
+
 implementation
 
-resourcestring
-  // Says TIMEOUT out loud and quotes the deadline: whoever debugs a red future has to be
-  // able to tell "the task failed" apart from "the task ran out of time".
-  SAsyncAwaitTimeout = 'Async await TIMEOUT: the task did not complete within %d ms. ' +
+const
+  // FROZEN PUBLIC CONTRACT - DO NOT TRANSLATE, DO NOT REWORD THE PREFIX.
+  // ------------------------------------------------------------------
+  // A timeout is only distinguishable from a task failure by this message: TFuture carries
+  // FValue/FErr/FIsOk/FIsErr and nothing that says WHY it is red. Two ways out were considered:
+  //
+  //   (a) give TFuture a discriminator (an error-kind enum, or an IsTimeout flag);
+  //   (b) freeze the message and expose the classification in exactly one place.
+  //
+  // (b) was chosen, deliberately, because (a) changes public surface that is not this unit's to
+  // change. TFuture lives in ModernSyntax.pas, is the return type of the whole Async API AND of
+  // TFuncCoroutine in ModernSyntax.Coroutine, and is built by consumers directly through
+  // SetOk/SetErr. A new state that only Await knows how to set would default to "not a timeout"
+  // in every existing SetErr call site - inside this repository and in consumer code - so the
+  // discriminator would be correct only where it was retrofitted and quietly wrong everywhere
+  // else. That is a worse contract than a frozen string.
+  //
+  // Consequences of the choice, all intentional:
+  //   * this is a const, NOT a resourcestring - a resourcestring is exactly what a translation
+  //     tool patches, and translating it would break every consumer and the test suite at once,
+  //     silently. Making it non-localizable is the enforcement, not just the documentation;
+  //   * the ASCII prefix in C_AWAIT_TIMEOUT_TAG is the contract. The tail after the tag is free
+  //     to be improved; the tag is not;
+  //   * consumers must classify with IsAwaitTimeout, never with their own Pos/Copy over Err.
+  //
+  // If a discriminator is ever wanted, it is an additive change to TFuture with a migration for
+  // every SetErr call site - a separate PR, not a side effect of a documentation pass.
+  C_AWAIT_TIMEOUT_TAG = 'Async await TIMEOUT:';
+  C_AWAIT_TIMEOUT_MESSAGE = C_AWAIT_TIMEOUT_TAG + ' the task did not complete within %d ms. ' +
     'The task was not canceled and may still be running; its result and any exception it ' +
     'raises are discarded.';
 
@@ -127,7 +192,20 @@ end;
 
 function _AwaitTimeoutMessage(const ATimeout: Cardinal): String;
 begin
-  Result := Format(SAsyncAwaitTimeout, [ATimeout]);
+  Result := Format(C_AWAIT_TIMEOUT_MESSAGE, [ATimeout]);
+end;
+
+function IsAwaitTimeout(const AFuture: TFuture): Boolean;
+var
+  LErr: String;
+begin
+  Result := False;
+  if not AFuture.IsErr then
+    Exit;
+  LErr := AFuture.Err;
+  // Anchored at position 1 on purpose: a task whose own exception message merely CONTAINS the
+  // word must not be misread as a blown deadline.
+  Result := Copy(LErr, 1, Length(C_AWAIT_TIMEOUT_TAG)) = C_AWAIT_TIMEOUT_TAG;
 end;
 
 function Async(const AProc: TProc): TAsync;

--- a/Source/ModernSyntax.ResultPair.pas
+++ b/Source/ModernSyntax.ResultPair.pas
@@ -155,6 +155,22 @@ type
     ///   returns without touching released memory. It is also safe on a pair whose S/F slot was
     ///   never set and on a slot holding nil.
     ///
+    ///   IDEMPOTENCE IS PER INSTANCE, NOT PER OBJECT. TResultPair is an unmanaged record, so
+    ///   assigning it (or passing it by value, or going through one of the Implicit operators)
+    ///   produces an INDEPENDENT copy that holds the SAME object pointer. Clearing the slot
+    ///   clears it in one copy only. Two copies with one Dispose each therefore free the same
+    ///   object TWICE:
+    ///
+    ///     LA := TResultPair&lt;TObject, TObject&gt;.New.Success(TObject.Create);
+    ///     LB := LA;      // independent copy, same pointer
+    ///     LA.Dispose;    // frees the object, clears LA's slot only
+    ///     LB.Dispose;    // DOUBLE FREE - LB's slot still points at the released object
+    ///
+    ///   The guarantee is "Dispose twice through the SAME variable is harmless", which is what
+    ///   protects a cleanup path that runs more than once. It is NOT "the object can only ever
+    ///   be freed once". Exactly one copy must own the value; decide which one and dispose only
+    ///   that one.
+    ///
     ///   STILL MANUAL BY DESIGN: TResultPair is a plain (unmanaged) record and deliberately has
     ///   NO class operator Finalize. Going out of scope frees nothing; ownership of any class
     ///   value stays with the caller. See the note above the implementation of _DestroyFailure
@@ -631,9 +647,18 @@ end;
 //     release, which is why the consume-helper exists"). Finalize would both fail that test
 //     and crash it.
 //
-//  4) Custom managed records (Initialize/Finalize/Assign) require Delphi 10.4+; this unit is
-//     built for the compatibility matrix in ModernSyntax.inc (Delphi 2010 upwards) and for
-//     FPC/Lazarus. Adding them would drop compilers that work today.
+//  4) Custom managed records (Initialize/Finalize/Assign) require Delphi 10.4+, and the
+//     supported floor is Delphi XE - README.md:3 (badge) and README.md:33 (compatibility
+//     matrix). Adding them would drop every compiler from XE to 10.3 that builds this unit
+//     today, which is the whole lower half of the declared matrix.
+//     (Correcting the earlier wording of this item: it cited ModernSyntax.inc and "Delphi 2010
+//     upwards" and an FPC/Lazarus target, and all three were wrong. This unit does NOT include
+//     ModernSyntax.inc - the only {$I} in the project is at ModernSyntax.Objects.pas:16 - and
+//     no unit anywhere in the repository consumes a single symbol that file defines, so the
+//     .inc does not set the floor; the README does. FPC/Lazarus is not a build target either:
+//     the .inc's Lazarus block is dead code, guarded by {$IFDEF FCP} - a typo for FPC - at
+//     ModernSyntax.inc:256. The CONCLUSION is unaffected: 10.4+ is still above the XE floor,
+//     so Finalize still cannot be used.)
 //
 // So ownership stays explicit: Dispose is the single, MANUAL release point - and it is now
 // idempotent, so calling it twice (or after someone else already released through the same
@@ -681,6 +706,35 @@ begin
     Result := _ReturnFailure;
 end;
 
+// KNOWN BUG - see https://github.com/ModernDelphiWorks/ModernSyntax/issues/8
+// -------------------------------------------------------------------------
+// Two defects live in this routine (and identically in _ReturnSuccess below). They are NOT
+// fixed here on purpose: the correct fix is an ownership refactor of the whole Return chain,
+// which changes what Return gives back, so it belongs in its own PR with its own tests.
+//
+//  1) THE TRANSFORMATION IS DISCARDED. `Result := Self` happens BEFORE the loop, while
+//     _SetSuccessValue/_SetFailureValue write into Self. Result is a separate copy taken
+//     beforehand, so the value handed back is the PRE-transformation one. TResultPair is a
+//     record, so Self is the caller's own variable and the mutation does land there - which
+//     means `x := x.Return` and `x.Return` disagree about the outcome.
+//
+//  2) USE-AFTER-FREE. _SetFailureValue(LResult.ValueFailure) copies the POINTER out of
+//     LResult; the `finally` then does LResult.Dispose, which frees the object behind that
+//     pointer. Self.FFailure is left holding released memory. Same shape for the success
+//     branch.
+//
+// CHANGE OF BEHAVIOUR INTRODUCED BY PR #7 (for TResultPair<class, class> only):
+//   before #7 - LResult.Dispose entered _DestroySuccess, called FSuccess.GetValue on a slot
+//               that had never been set and raised 'Value is nil.'. The exception escaped the
+//               `finally`, _DestroyFailure never ran and the object was never freed. An
+//               ACCIDENTAL SHIELD: loud, and no dangling pointer.
+//   after  #7 - _DestroySuccess returns early on `not FSuccess.HasValue`, _DestroyFailure runs
+//               and frees the object. Verified by address comparison: `dangling? True`, and
+//               SILENT.
+// For a non-class S nothing changed (_DestroySuccess bailed out at the tkClass check both
+// before and after), so there the dangling pointer is equally old. #7 is still a net win, but
+// for <class, class> it traded a noisy abort for a quiet use-after-free, and the record has to
+// say so.
 function TResultPair<S, F>._ReturnFailure: TResultPair<S, F>;
 var
   LFor: Integer;
@@ -702,6 +756,25 @@ begin
   end;
 end;
 
+// KNOWN BUG - see https://github.com/ModernDelphiWorks/ModernSyntax/issues/8
+// -------------------------------------------------------------------------
+// Same two defects documented above _ReturnFailure, plus one of its own:
+//
+//  1) THE TRANSFORMATION IS DISCARDED. `Result := Self` below is taken before the loop, and
+//     _SetSuccessValue/_SetFailureValue write into Self, so the returned pair carries the
+//     pre-transformation state.
+//
+//  2) USE-AFTER-FREE. The value is adopted with _SetSuccessValue(LResult.ValueSuccess) and the
+//     `finally` immediately disposes LResult, freeing the object the adopted pointer refers to.
+//     Post-#7 this is silent for <class, class>; pre-#7 it aborted with 'Value is nil.'. Full
+//     account in the note above _ReturnFailure.
+//
+//  3) THE CHAIN DOES NOT COMPOSE. Each step is fed from `Result.FSuccess.GetValue` - the stale
+//     copy - instead of the accumulating Self, so with two or more success functions every step
+//     sees the ORIGINAL value rather than its predecessor's output.
+//
+// Not fixed here for the same reason: the fix is an ownership refactor of the Return chain
+// (issue #8), which changes Return's observable result.
 function TResultPair<S, F>._ReturnSuccess: TResultPair<S, F>;
 var
   LFor: Integer;

--- a/Source/ModernSyntax.inc
+++ b/Source/ModernSyntax.inc
@@ -253,6 +253,17 @@
 {$ENDIF}
 
 //Lazarus
+// DEAD BLOCK - DO NOT "FIX" THE TYPO WITHOUT READING THIS.
+// The guard says FCP; the FPC/Lazarus symbol is FPC, so this block has never been taken.
+// Correcting it to {$IFDEF FPC} is not a no-op: it would start asserting that FPC provides
+// the Delphi 2010 feature level (DELPHI14_UP), a mapping nobody has ever compiled or tested
+// here - there is no FPC/Lazarus build of this library, and the declared floor is Delphi XE
+// (README.md:3 and README.md:33).
+// It is also, today, unobservable either way: this file is included by exactly one unit
+// (ModernSyntax.Objects.pas:16) and NO unit in the repository reads DELPHI14_UP - or any other
+// symbol defined below - so nothing changes behaviour whichever way the guard is spelled.
+// Left as-is on purpose: activating an unverified compatibility claim is worse than a typo in
+// code that no one reads. Fix it together with a real FPC target and a build that proves it.
 {$IFDEF FCP}
   {$DEFINE DELPHI14_UP}
 {$ENDIF}

--- a/Test Delphi/EclbrResultPair/UTestMS.ResultPair.pas
+++ b/Test Delphi/EclbrResultPair/UTestMS.ResultPair.pas
@@ -100,7 +100,7 @@ end;
 
 procedure TTestTResultPair.TearDown;
 begin
-  // Nï¿½o precisa de Dispose, liberaï¿½ï¿½o ï¿½ automï¿½tica
+  // Não precisa de Dispose, liberação é automática
 end;
 
 procedure TTestTResultPair.TestFailure;

--- a/Test Delphi/EclbrSystem/UTestMMS.Threading.pas
+++ b/Test Delphi/EclbrSystem/UTestMMS.Threading.pas
@@ -51,6 +51,8 @@ type
     [Test]
     procedure TestAwaitTaskExceptionKeepsItsMessage;
     [Test]
+    procedure TestIsAwaitTimeoutClassifiesWithoutStringSniffing;
+    [Test]
     procedure TestAwaitTaskExceptionWinsWhenTaskFinishedInTime;
   end;
 
@@ -165,9 +167,9 @@ var
   LFuture: TFuture;
   LErr: String;
 begin
-  // Neste caso no ECL o "Run" nï¿½o usa Function, mas somente Procedure, se quiser
+  // Neste caso no ECL o "Run" não usa Function, mas somente Procedure, se quiser
   // usar Function use o "Await", pois ele espera o resultado para devolver, o
-  // "Run" nï¿½o fica esperando, somente aloca a thread e executa
+  // "Run" não fica esperando, somente aloca a thread e executa
   LFuture := Async(function: TValue
                    begin
                      Result := False;
@@ -214,9 +216,9 @@ begin
   try
     Assert.IsTrue(LFuture.IsErr, 'an expired deadline is an ERROR');
     Assert.IsFalse(LFuture.IsOk, 'and it must NOT be reported as a success');
-    Assert.IsTrue(Pos('TIMEOUT', LFuture.Err) > 0,
-      'the message has to say TIMEOUT so it can be told apart from "the task failed": ' +
-      LFuture.Err);
+    Assert.IsTrue(IsAwaitTimeout(LFuture),
+      'it has to be classifiable as a TIMEOUT, so it can be told apart from "the task ' +
+      'failed": ' + LFuture.Err);
     Assert.IsTrue(Pos(IntToStr(CDeadlineMs) + ' ms', LFuture.Err) > 0,
       'the message has to quote the deadline that was blown: ' + LFuture.Err);
   finally
@@ -239,7 +241,7 @@ begin
   LFuture := LAsync.Await(CDeadlineMs);
   try
     Assert.IsTrue(LFuture.IsErr, 'an expired deadline is an ERROR');
-    Assert.IsTrue(Pos('TIMEOUT', LFuture.Err) > 0, 'and it says TIMEOUT: ' + LFuture.Err);
+    Assert.IsTrue(IsAwaitTimeout(LFuture), 'and it classifies as a TIMEOUT: ' + LFuture.Err);
     Assert.WillRaise(
       procedure
       begin
@@ -336,7 +338,46 @@ begin
 
   Assert.IsTrue(LFuture.IsErr, 'a task that raises produces an error future');
   Assert.AreEqual('task blew up', LFuture.Err, 'the task message is preserved verbatim');
-  Assert.IsTrue(Pos('TIMEOUT', LFuture.Err) = 0, 'a failure is not a timeout');
+  Assert.IsFalse(IsAwaitTimeout(LFuture), 'a failure is not a timeout');
+end;
+
+procedure TTesTStd.TestIsAwaitTimeoutClassifiesWithoutStringSniffing;
+var
+  LAsync: TAsync;
+  LTimedOut: TFuture;
+  LTaskFailed: TFuture;
+  LSucceeded: TFuture;
+begin
+  // The whole point of IsAwaitTimeout: consumers used to write Pos('TIMEOUT', LFuture.Err),
+  // which misfires on any task message that merely CONTAINS the word. The classification is
+  // anchored at the start of the message, so a task that raises with the word in it is still
+  // a task failure.
+  LTaskFailed := Async(procedure
+                       begin
+                         raise Exception.Create('gateway said TIMEOUT while reading the socket');
+                       end)
+                .Await;
+  Assert.IsTrue(LTaskFailed.IsErr, 'the task raised, so the future is red');
+  Assert.IsFalse(IsAwaitTimeout(LTaskFailed),
+    'a task message that merely mentions TIMEOUT is NOT an await timeout');
+
+  LSucceeded := Async(procedure
+                      begin
+                      end)
+               .Await(CGenerousMs);
+  Assert.IsTrue(LSucceeded.IsOk);
+  Assert.IsFalse(IsAwaitTimeout(LSucceeded), 'a green future is never a timeout');
+
+  LAsync := Async(procedure
+                  begin
+                    Sleep(CTaskSleepMs);
+                  end);
+  LTimedOut := LAsync.Await(CDeadlineMs);
+  try
+    Assert.IsTrue(IsAwaitTimeout(LTimedOut), 'and the real thing still classifies as one');
+  finally
+    Sleep(CDrainMs);
+  end;
 end;
 
 procedure TTesTStd.TestAwaitTaskExceptionWinsWhenTaskFinishedInTime;


### PR DESCRIPTION
## Why

PR #7 fixed two real bugs, but it also **recorded a false claim in the code** and **lost data
in two test files**. This PR corrects the record, documents the hazards #7 uncovered but did
not fix, and restores the lost characters. It changes **no runtime behaviour** except for one
additive helper.

## 1. The false claim (`KNOWN BUG` in `ModernSyntax.ResultPair.pas`)

#7 stated that the use-after-free in `_ReturnSuccess`/`_ReturnFailure` was *"pre-existing and
not aggravated"*. **That is false for `TResultPair<class, class>`**:

| | before #7 | after #7 |
|---|---|---|
| `LResult.Dispose` with an unset success slot | `_DestroySuccess` called `GetValue` on an empty slot, raised `'Value is nil.'`; the exception escaped the `finally`, `_DestroyFailure` never ran, the object was **never freed** — an accidental shield | `_DestroySuccess` returns early on `not HasValue`, `_DestroyFailure` runs and frees the object |
| observable | loud abort, no dangling pointer | **silent dangling pointer** (`dangling? True`) |

For a non-class `S` nothing changed — both versions bailed out at the `tkClass` check — so
*there* the claim held. #7 remains a net win; the record just has to be accurate.

Two `KNOWN BUG` blocks were added, at `_ReturnFailure` and `_ReturnSuccess`, covering:

1. **The transformation is discarded.** `Result := Self` is taken *before* the loop, while
   `_SetSuccessValue`/`_SetFailureValue` write into `Self`. The returned pair carries the
   pre-transformation state, so `x := x.Return` and `x.Return` disagree.
2. **Use-after-free.** `_Set*Value` adopts the pointer out of `LResult`; the `finally`
   immediately disposes `LResult`, freeing the object behind it.
3. **The chain does not compose.** `_ReturnSuccess` feeds every step from
   `Result.FSuccess.GetValue` — the stale copy — instead of the accumulating `Self`.

Not fixed here on purpose: the fix is an **ownership refactor of the `Return` chain**, which
changes what `Return` gives back. Tracked in **#8**, referenced from both comments.

## 2. `Dispose` docstring — idempotence is per instance, not per object

The interface only said "twice on the same instance". `TResultPair` is unmanaged, so a copy is
an independent record holding the **same pointer**; clearing the slot clears one copy only.
Two copies with one `Dispose` each still free twice. That now appears in the `<remarks>` — the
part a consumer actually reads — with a worked example. It was previously only implied by an
implementation comment.

## 3. The `Finalize` justification cited three wrong facts

Item 4 of the "why there is no `class operator Finalize`" note claimed the unit is built for
`ModernSyntax.inc` (Delphi 2010 upwards) and for FPC/Lazarus. All three are wrong:

- the unit **does not include** `ModernSyntax.inc` — the only `{$I}` in the project is at
  `ModernSyntax.Objects.pas:16` — and **no unit in the repository consumes any symbol** the
  `.inc` defines (verified repo-wide for `DELPHI1x_UP`, `FORMATSETTINGS`, `HAS_*`, `HAS_VCL`);
- the declared floor is **Delphi XE** (`README.md:3` badge, `README.md:33` matrix), not 2010;
- FPC/Lazarus is not a target: the `.inc`'s Lazarus block is dead code, guarded by
  `{$IFDEF FCP}` — a typo for `FPC` — at `ModernSyntax.inc:256`.

**The decision itself is unchanged and still correct**: managed records need 10.4+, which is
above the XE floor. Only the reasoning was rewritten.

### The `FCP` typo — reported, deliberately not "fixed"

Correcting it to `{$IFDEF FPC}` is **not a no-op**: it would start asserting that FPC provides
the Delphi 2010 feature level (`DELPHI14_UP`), a mapping that has never been compiled or tested
here — there is no FPC/Lazarus build of this library. It is also *unobservable either way*
today, because nothing reads the symbol. Activating an unverified compatibility claim is worse
than a typo in code nobody reads, so the block stays as-is with an explanatory note at
`ModernSyntax.inc:255`. Fix it together with a real FPC target and a build that proves it.

## 4. Restored the accents lost in #7

Three comment lines had their accented characters replaced by `U+FFFD` when #7 re-encoded the
files: `Test Delphi/EclbrResultPair/UTestMS.ResultPair.pas:103` and
`Test Delphi/EclbrSystem/UTestMMS.Threading.pas:170,172`.

**Decision: back to CP1252, no BOM** — the exact bytes from
`backup/pre-fix-await-resultpair_2026-07-27`. Why, not "because it was like that":

- it is the house convention for accented Pascal in this repo — **13 of 15** non-ASCII source
  files are CP1252 without BOM, including every sibling test unit in both test folders
  (`UTestResultPair.pas`, `UTestMS.Currying.pas`, `UTestMS.Option.pas`, `UTestMS.Match.pas`,
  `UTestEcl.*`);
- **the compiler decides.** `dcc` reads a BOM-less source using the system ANSI codepage. A
  BOM-less UTF-8 file with accents is read as mojibake — harmless inside a `//` comment, wrong
  the moment an accent lands in a string literal. Keeping UTF-8 without a BOM would leave the
  file in exactly the state that makes this class of loss possible;
- adding a BOM was rejected as a gratuitous re-encode of files nobody asked to convert, and it
  would make these two files the only BOM'd sources in the tree;
- restoring the bytes gives the smallest possible diff: one changed line in one file, two in
  the other, and zero behaviour change.

## 5. `Await` `<remarks>` — the orphan task outlives the await

A timeout cancels nothing. The worker keeps running and keeps `LSelf := @Self`, a **raw
pointer** to the record (`ModernSyntax.Async.pas:258, :352, :406, :444`), which it dereferences
to reach `FProc`/`FFunc`. With a finite deadline the fluent form is therefore unsafe:

```pascal
LFuture := Async(LWork).Await(50);   // WRONG: the TAsync is a temporary

LAsync  := Async(LWork);             // RIGHT: named variable, outlives the orphan
LFuture := LAsync.Await(50);
```

Pre-existing, but previously unreachable in practice: with `INFINITE` the await only returns
once the task is done, so the record is never released early. Finite deadlines — and the
timeout/retry style they invite — are what turn it into a real exposure.

## 6. Telling a timeout apart from a failure — decision

The only discriminator was `Pos('TIMEOUT', Err)` over a `resourcestring`. Translating the
framework would break consumers **and** the suite, silently.

**Chosen: freeze the text as contract + expose the classification in one place.** Rejected:
giving `TFuture` a discriminator field.

`TFuture` lives in `ModernSyntax.pas`, is the return type of the entire `Async` API **and** of
`TFuncCoroutine`, and is built directly by consumers through `SetOk`/`SetErr`. A new state only
`Await` knows how to set would default to "not a timeout" at every existing `SetErr` call site,
inside this repo and in consumer code — correct only where retrofitted, quietly wrong
everywhere else. That is a worse contract than a frozen string, and it changes public surface
that is not this unit's to change. Per the brief, the conservative option wins.

Consequences, all intentional:

- the message is now a **`const`, not a `resourcestring`** — a resourcestring is precisely what
  translation tooling patches, so making it non-localizable *enforces* the rule instead of
  merely documenting it. It lived in the `implementation` section, so nothing outside the unit
  could reference it: the change is invisible to consumers;
- the ASCII prefix `Async await TIMEOUT:` is the contract; the tail may be improved;
- **added `IsAwaitTimeout(const AFuture: TFuture): Boolean`** — purely additive, anchored at
  position 1, so a task exception that merely *contains* the word is not misread as a blown
  deadline. The three `Pos('TIMEOUT', ...)` assertions in the suite now use it.

If a discriminator is ever wanted, it is an additive `TFuture` change with a migration for
every `SetErr` call site — its own PR.

## 7. BREAKING CHANGE (from #7, recorded here)

**`Await(timeout)` no longer returns `IsOk` after the deadline.**

Who breaks: anyone calling `Await` with a *finite* deadline as "fire and forget with a grace
period", reading `IsOk` afterwards and carrying on. That code used to see `IsOk = True` for
work that had not finished; it now sees `IsErr = True`. Every branch keyed on `IsOk` inverts.

Who does not: `Await` and `Await(INFINITE)` — the parameter default — are provably unchanged
(`_AwaitTimedOut` only reports a timeout when `ATimeout <> INFINITE`). To keep the old
semantics, drop the argument.

The repository had no `CHANGELOG`, so one was created (`CHANGELOG.md`, Keep a Changelog
format), starting at `v1.2.0`, with the breaking change, the migration snippet and this PR's
entries. #7 landed after the `v1.2.0` tag, so it sits under `[Unreleased]`.

## Gate

| | result |
|---|---|
| `PTestAsync` (Win32, Delphi 12) | **15 / 15** — was 14/14, +1 new test |
| `PTestResultPair` (Win32, Delphi 12) | **27 / 27** |
| All 16 `Source` units, Win32 | compile clean (only the pre-existing `H2509` hint in `ModernSyntax.Option.pas:61`) |
| All 16 `Source` units, Win64 | compile clean (same pre-existing hint) |
| `Async`, `ResultPair`, `Coroutine`, `dcclinux64` | compile clean |

The Axial suite was **not** run — another agent is writing in that clone.

## What is deliberately NOT in this PR

- the `Return` ownership refactor -> **#8**;
- the `FCP` -> `FPC` typo -> reported above, note left in the `.inc`;
- a `TFuture` discriminator -> rejected with rationale in section 6.
