### PR TITLE
fix(coroutine): Stop reports whether it actually stopped; destructor no longer frees under a live worker

### DIFF
--- a/Source/ModernSyntax.Coroutine.pas
+++ b/Source/ModernSyntax.Coroutine.pas
@@ -25,9 +25,42 @@ uses
   Generics.Collections,
   ModernSyntax;
 
+const
+  /// <summary>
+  ///   Default deadline, in milliseconds, for an explicit <c>IScheduler.Stop</c>.
+  /// </summary>
+  /// <remarks>
+  ///   Single source of truth on purpose. IScheduler.Stop used to default to 1000 while
+  ///   TScheduler.Stop defaulted to 500, so the deadline you actually got depended on whether
+  ///   the call went through the interface or the class - and every caller goes through the
+  ///   interface, so 1000 was the effective default. Both declarations now use this constant.
+  /// </remarks>
+  C_STOP_TIMEOUT = 1000;
+
+  /// <summary>
+  ///   Deadline, in milliseconds, the destructor gives the worker before abandoning it.
+  /// </summary>
+  /// <remarks>
+  ///   Deliberately far more generous than C_STOP_TIMEOUT: at destruction there is no second
+  ///   chance. Whatever the destructor does not wait for, it either abandons (leaks) or
+  ///   corrupts. Override per instance with TScheduler.New's second parameter.
+  /// </remarks>
+  C_SHUTDOWN_TIMEOUT = 5000;
+
+  /// <summary>
+  ///   Bounded budget, in milliseconds, for taking FLock inside Stop.
+  /// </summary>
+  C_STOP_LOCK_BUDGET = 250;
+
 type
   TFuture = ModernSyntax.TFuture;
   IScheduler = interface;
+
+  /// <summary>
+  ///   Notified when a TScheduler had to be abandoned because its worker was still running at
+  ///   destruction. <paramref name="ATimeoutMs"/> is the deadline that was given and blown.
+  /// </summary>
+  TSchedulerAbandonEvent = reference to procedure(const ATimeoutMs: Cardinal);
 
   TFuncCoroutine = reference to function(const ASendValue: TValue; const AValue: TValue): TFuture;
 
@@ -104,7 +137,25 @@ type
     procedure Send(const AName: String; const AValue: TValue);
     procedure Suspend(const AName: String);
     procedure Resume(const AName: String);
-    procedure Stop(const ATimeout: Cardinal = 1000);
+
+    /// <summary>
+    ///   Asks the scheduler to stop and waits up to <paramref name="ATimeout"/> milliseconds
+    ///   for the worker to actually finish.
+    /// </summary>
+    /// <returns>
+    ///   True when the worker really stopped inside the deadline; False when the deadline
+    ///   expired with the worker STILL RUNNING.
+    /// </returns>
+    /// <remarks>
+    ///   THE RESULT IS NOT DECORATION. Until this became a function the Boolean returned by
+    ///   ITask.Wait was discarded here - the same defect that made TAsync.Await report success
+    ///   on a blown deadline. Stop looked like it had stopped the scheduler even when it had
+    ///   not, and callers then released resources the worker was still touching.
+    ///   A False result means the coroutines are STILL EXECUTING: do not free anything they
+    ///   can reach, and do not assume the scheduler is idle.
+    ///   Stop is idempotent and may be called again with a longer deadline.
+    /// </remarks>
+    function Stop(const ATimeout: Cardinal = C_STOP_TIMEOUT): Boolean;
     procedure Next;
     function Add(const AName: String; const ARoutine: TFuncCoroutine; const AValue: TValue;
       const AProc: TProc = nil; const AInterval: UInt32 = 0): IScheduler;
@@ -131,6 +182,9 @@ type
     const
       C_COROUTINE_NOT_FOUND = 'No coroutine found with the specified name.';
   strict private
+    class var FAbandonedCount: Integer;
+    class var FOnAbandon: TSchedulerAbandonEvent;
+  strict private
     FSleepTime: UInt16;
     FCurrentRoutine: TCoroutine;
     FCoroutines: TGather<TCoroutine>;
@@ -143,17 +197,57 @@ type
     FLock: TCriticalSection;
     FOnStarted: TProc;
     FOnFinished: TProc;
+    FShutdownTimeout: Cardinal;
+    FAbandoned: Boolean;
     function _GetCoroutine(AValue: String): TCoroutine;
+    function _TryAcquireLock(const ABudgetMs: Cardinal): Boolean;
+    procedure _Abandon(const ATimeoutMs: Cardinal);
   protected
     function Run: IScheduler; overload;
-    constructor Create(const ASleepTime: UInt16);
+    constructor Create(const ASleepTime: UInt16; const AShutdownTimeout: Cardinal);
   public
-    class function New(const ASleepTime: UInt16 = 500): IScheduler;
+    class function New(const ASleepTime: UInt16 = 500;
+      const AShutdownTimeout: Cardinal = C_SHUTDOWN_TIMEOUT): IScheduler;
+
+    /// <summary>
+    ///   How many TScheduler instances have been abandoned so far in this process, i.e. how
+    ///   many times the destructor found the worker still running past its deadline and chose
+    ///   to leak rather than free memory the worker still dereferences.
+    /// </summary>
+    /// <remarks>
+    ///   Non-zero is a defect signal in the HOST application, not in the scheduler: something
+    ///   is destroying a scheduler whose coroutines will not yield. Also the observation point
+    ///   for tests, since an abandoned instance cannot report anything about itself.
+    /// </remarks>
+    class function AbandonedCount: Integer; static;
+    class procedure ResetAbandonedCount; static;
+
+    /// <summary>
+    ///   Optional hook invoked when an instance is abandoned. Left nil by default: this unit
+    ///   deliberately does not pick an I/O channel (a destructor writing to stderr in a GUI
+    ///   process is its own kind of bug). Exceptions raised by the handler are swallowed.
+    /// </summary>
+    class property OnAbandon: TSchedulerAbandonEvent read FOnAbandon write FOnAbandon;
+
     destructor Destroy; override;
+
+    /// <summary>
+    ///   Releases the instance memory, UNLESS this scheduler was abandoned.
+    /// </summary>
+    /// <remarks>
+    ///   TObject.FreeInstance is CleanupInstance + _FreeMem, so skipping it keeps BOTH the
+    ///   object storage and its managed fields (FTask, the TValues, the closures) alive. That
+    ///   is the whole point: an abandoned scheduler still has a worker thread dereferencing
+    ///   Self, and freeing the storage under it is exactly the use-after-free this change
+    ///   exists to prevent. Leaking a scheduler is bounded and diagnosable; corrupting the heap
+    ///   from a background thread is neither.
+    /// </remarks>
+    procedure FreeInstance; override;
+
     procedure Send(const AName: String; const AValue: TValue);
     procedure Suspend(const AName: String);
     procedure Resume(const AName: String);
-    procedure Stop(const ATimeout: Cardinal = 500);
+    function Stop(const ATimeout: Cardinal = C_STOP_TIMEOUT): Boolean;
     procedure Next;
     function Add(const AName: String; const ARoutine: TFuncCoroutine; const AValue: TValue;
       const AProc: TProc = nil; const AInterval: UInt32 = 0): IScheduler;
@@ -197,24 +291,93 @@ begin
   Result := FCurrentRoutine.SendValue;
 end;
 
-constructor TScheduler.Create(const ASleepTime: UInt16);
+constructor TScheduler.Create(const ASleepTime: UInt16; const AShutdownTimeout: Cardinal);
 begin
   FStoped := False;
+  FAbandoned := False;
   FSleepTime := ASleepTime;
+  FShutdownTimeout := AShutdownTimeout;
   FException := Default(TException);
   FCoroutines := TGather<TCoroutine>.Create;
   FLock := TCriticalSection.Create;
 end;
 
+class function TScheduler.AbandonedCount: Integer;
+begin
+  Result := FAbandonedCount;
+end;
+
+class procedure TScheduler.ResetAbandonedCount;
+begin
+  FAbandonedCount := 0;
+end;
+
+procedure TScheduler._Abandon(const ATimeoutMs: Cardinal);
+begin
+  FAbandoned := True;
+  AtomicIncrement(FAbandonedCount);
+  if not Assigned(FOnAbandon) then
+    Exit;
+  try
+    FOnAbandon(ATimeoutMs);
+  except
+    // A destructor must not propagate, least of all because of a diagnostic hook.
+  end;
+end;
+
+procedure TScheduler.FreeInstance;
+begin
+  if FAbandoned then
+    Exit;
+  inherited FreeInstance;
+end;
+
+// SHUTDOWN CONTRACT
+// -----------------
+// The worker started by Run dereferences Self on every iteration: it reads FStoped, calls Next
+// (which takes FLock and walks FCoroutines) and finally FOnFinished. The old destructor gave it
+// Stop(500), IGNORED the answer, and then freed the coroutines, the list and the lock - so any
+// worker that had not finished in 500 ms was left walking released memory. Use-after-free at
+// shutdown, on a background thread, which is the hardest possible place to diagnose it.
+//
+// There is no third option here. Either the destructor waits until the worker is provably done,
+// or it must not touch anything the worker can reach. Waiting forever is not acceptable either:
+// a coroutine body that never returns would hang process shutdown with no way out.
+//
+// The middle ground, in order:
+//   1) ask to stop and wait FShutdownTimeout (default 5 s - ten times the old deadline, and
+//      per-instance tunable through TScheduler.New for callers with harder shutdown budgets);
+//   2) if it stopped, free everything exactly as before;
+//   3) if it did NOT stop, ABANDON: free nothing, skip FreeInstance, count it and fire
+//      OnAbandon. The process leaks one scheduler and its coroutines - bounded, visible through
+//      AbandonedCount, and infinitely preferable to heap corruption from a live thread.
+// A non-zero AbandonedCount is a bug report about the host: some coroutine is not yielding.
 destructor TScheduler.Destroy;
 var
   LItem: TCoroutine;
+  LStopped: Boolean;
 begin
-  Stop(500);
+  try
+    LStopped := Stop(FShutdownTimeout);
+  except
+    // ITask.Wait re-raises whatever the worker raised. A faulted task is a FINISHED task, and
+    // "finished" is the only thing this decision depends on.
+    LStopped := True;
+  end;
+
+  if not LStopped then
+  begin
+    _Abandon(FShutdownTimeout);
+    inherited;
+    Exit;
+  end;
+
   for LItem in FCoroutines do
     LItem.Free;
   FCoroutines.Free;
+  FCoroutines := nil;
   FLock.Free;
+  FLock := nil;
   inherited;
 end;
 
@@ -311,21 +474,49 @@ begin
   Result := Self;
 end;
 
-procedure TScheduler.Stop(const ATimeout: Cardinal);
+function TScheduler._TryAcquireLock(const ABudgetMs: Cardinal): Boolean;
+var
+  LStart: TDateTime;
+begin
+  LStart := Now;
+  repeat
+    Result := FLock.TryEnter;
+    if Result then
+      Exit;
+    Sleep(1);
+  until Cardinal(MilliSecondsBetween(Now, LStart)) >= ABudgetMs;
+end;
+
+function TScheduler.Stop(const ATimeout: Cardinal): Boolean;
 var
   LCoroutine: TCoroutine;
 begin
-  FLock.Acquire;
-  try
-    FStoped := True;
-    for LCoroutine in FCoroutines do
-      if LCoroutine.State = TCoroutineState.csPaused then
-        LCoroutine.State := TCoroutineState.csActive;
-  finally
-    FLock.Release;
+  // The stop flag is published WITHOUT the lock, on purpose. It is a plain Boolean that the
+  // worker only polls (Run's `while not FStoped`, which already read it unsynchronised), and
+  // taking the lock first would block forever whenever a coroutine body hangs while Next holds
+  // it - precisely the case Stop has to survive. Requesting a stop must never be the thing that
+  // hangs.
+  FStoped := True;
+
+  // The un-pause walk DOES need the lock, because it touches FCoroutines. Bounded, so a hung
+  // coroutine cannot turn Stop into an unbounded wait. Skipping it costs nothing for
+  // termination: the loop exits on FStoped regardless of any paused state.
+  if _TryAcquireLock(C_STOP_LOCK_BUDGET) then
+  begin
+    try
+      for LCoroutine in FCoroutines do
+        if LCoroutine.State = TCoroutineState.csPaused then
+          LCoroutine.State := TCoroutineState.csActive;
+    finally
+      FLock.Release;
+    end;
   end;
-  if Assigned(FTask) then
-    FTask.Wait(ATimeout);
+
+  // THE POINT OF THE CHANGE: ITask.Wait's Boolean was discarded here, exactly as it was in
+  // TAsync.Await before #7, so Stop could not tell "stopped" from "gave up waiting".
+  if not Assigned(FTask) then
+    Exit(True);            // never started: there is nothing still running
+  Result := FTask.Wait(ATimeout);
 end;
 
 function TScheduler.Value: TValue;
@@ -350,9 +541,10 @@ begin
   end;
 end;
 
-class function TScheduler.New(const ASleepTime: UInt16): IScheduler;
+class function TScheduler.New(const ASleepTime: UInt16;
+  const AShutdownTimeout: Cardinal): IScheduler;
 begin
-  Result := TScheduler.Create(ASleepTime);
+  Result := TScheduler.Create(ASleepTime, AShutdownTimeout);
 end;
 
 procedure TScheduler.Next;

--- a/Test Delphi/EclbrSystem/PTestCoroutine.dpr
+++ b/Test Delphi/EclbrSystem/PTestCoroutine.dpr
@@ -1,0 +1,80 @@
+program PTestCoroutine;
+
+//{$DEFINE CI}
+
+{$IFNDEF TESTINSIGHT}
+{$APPTYPE CONSOLE}
+{$ENDIF}
+{$STRONGLINKTYPES ON}
+
+// NOTE: FastMM4 is deliberately NOT linked here, unlike the sibling test projects.
+// TestDestructorAbandonsAWorkerThatWillNotStop leaks ONE scheduler on purpose - that is the
+// behaviour under test: when a worker will not stop, the destructor must leak rather than free
+// memory a live thread still dereferences. FastMM's leak report would flag that intentional
+// leak as a failure at shutdown. The test also carries [IgnoreMemoryLeaks(True)] for DUnitX.
+
+uses
+  System.SysUtils,
+  {$IFDEF TESTINSIGHT}
+  TestInsight.DUnitX,
+  {$ELSE}
+  DUnitX.Loggers.Console,
+  DUnitX.Loggers.Xml.NUnit,
+  {$ENDIF }
+  DUnitX.TestFramework,
+  UTestMS.Coroutine in 'UTestMS.Coroutine.pas',
+  ModernSyntax.Coroutine in '..\..\Source\ModernSyntax.Coroutine.pas',
+  ModernSyntax in '..\..\Source\ModernSyntax.pas';
+
+{$IFNDEF TESTINSIGHT}
+var
+  runner: ITestRunner;
+  results: IRunResults;
+  logger: ITestLogger;
+  nunitLogger : ITestLogger;
+{$ENDIF}
+begin
+{$IFDEF TESTINSIGHT}
+  TestInsight.DUnitX.RunRegisteredTests;
+{$ELSE}
+  try
+    //Check command line options, will exit if invalid
+    TDUnitX.CheckCommandLine;
+    //Create the test runner
+    runner := TDUnitX.CreateRunner;
+    //Tell the runner to use RTTI to find Fixtures
+    runner.UseRTTI := True;
+    //When true, Assertions must be made during tests;
+    runner.FailsOnNoAsserts := False;
+
+    //tell the runner how we will log things
+    //Log to the console window if desired
+    if TDUnitX.Options.ConsoleMode <> TDunitXConsoleMode.Off then
+    begin
+      logger := TDUnitXConsoleLogger.Create(TDUnitX.Options.ConsoleMode = TDunitXConsoleMode.Quiet);
+      runner.AddLogger(logger);
+    end;
+    //Generate an NUnit compatible XML File
+    nunitLogger := TDUnitXXMLNUnitFileLogger.Create(TDUnitX.Options.XMLOutputFile);
+    runner.AddLogger(nunitLogger);
+
+    //Run tests
+    results := runner.Execute;
+    if not results.AllPassed then
+      System.ExitCode := EXIT_ERRORS;
+
+    {$IFNDEF CI}
+    //We don't want this happening when running under CI.
+    TDUnitX.Options.ExitBehavior := TDUnitXExitBehavior.Pause;
+    if TDUnitX.Options.ExitBehavior = TDUnitXExitBehavior.Pause then
+    begin
+      System.Write('Done.. press <Enter> key to quit.');
+      System.Readln;
+    end;
+    {$ENDIF}
+  except
+    on E: Exception do
+      System.Writeln(E.ClassName, ': ', E.Message);
+  end;
+{$ENDIF}
+end.

--- a/Test Delphi/EclbrSystem/PTestCoroutine.dproj
+++ b/Test Delphi/EclbrSystem/PTestCoroutine.dproj
@@ -1,0 +1,1084 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <ProjectGuid>{3F1C6A42-5B7D-49E8-9C21-8A6D4E0B7F13}</ProjectGuid>
+        <ProjectVersion>20.4</ProjectVersion>
+        <FrameworkType>None</FrameworkType>
+        <Base>True</Base>
+        <Config Condition="'$(Config)'==''">Debug</Config>
+        <Platform Condition="'$(Platform)'==''">Win32</Platform>
+        <TargetedPlatforms>3</TargetedPlatforms>
+        <AppType>Console</AppType>
+        <MainSource>PTestCoroutine.dpr</MainSource>
+        <ProjectName Condition="'$(ProjectName)'==''">PTestCoroutine</ProjectName>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Base' or '$(Base)'!=''">
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='iOSDevice64' and '$(Base)'=='true') or '$(Base_iOSDevice64)'!=''">
+        <Base_iOSDevice64>true</Base_iOSDevice64>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='iOSSimARM64' and '$(Base)'=='true') or '$(Base_iOSSimARM64)'!=''">
+        <Base_iOSSimARM64>true</Base_iOSSimARM64>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='OSX64' and '$(Base)'=='true') or '$(Base_OSX64)'!=''">
+        <Base_OSX64>true</Base_OSX64>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='OSXARM64' and '$(Base)'=='true') or '$(Base_OSXARM64)'!=''">
+        <Base_OSXARM64>true</Base_OSXARM64>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win32' and '$(Base)'=='true') or '$(Base_Win32)'!=''">
+        <Base_Win32>true</Base_Win32>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win64' and '$(Base)'=='true') or '$(Base_Win64)'!=''">
+        <Base_Win64>true</Base_Win64>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Debug' or '$(Cfg_1)'!=''">
+        <Cfg_1>true</Cfg_1>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win32' and '$(Cfg_1)'=='true') or '$(Cfg_1_Win32)'!=''">
+        <Cfg_1_Win32>true</Cfg_1_Win32>
+        <CfgParent>Cfg_1</CfgParent>
+        <Cfg_1>true</Cfg_1>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win64' and '$(Cfg_1)'=='true') or '$(Cfg_1_Win64)'!=''">
+        <Cfg_1_Win64>true</Cfg_1_Win64>
+        <CfgParent>Cfg_1</CfgParent>
+        <Cfg_1>true</Cfg_1>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Release' or '$(Cfg_2)'!=''">
+        <Cfg_2>true</Cfg_2>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base)'!=''">
+        <DCC_DcuOutput>.\$(Platform)\$(Config)</DCC_DcuOutput>
+        <DCC_E>false</DCC_E>
+        <DCC_N>false</DCC_N>
+        <DCC_S>false</DCC_S>
+        <DCC_F>false</DCC_F>
+        <DCC_K>false</DCC_K>
+        <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;$(DCC_Namespace)</DCC_Namespace>
+        <UsingDelphiRTL>true</UsingDelphiRTL>
+        <Icon_MainIcon>$(BDS)\bin\delphi_PROJECTICON.ico</Icon_MainIcon>
+        <Icns_MainIcns>$(BDS)\bin\delphi_PROJECTICNS.icns</Icns_MainIcns>
+        <DCC_UnitSearchPath>$(DUnitX);$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+        <SanitizedProjectName>PTestCoroutine</SanitizedProjectName>
+        <VerInfo_Locale>1046</VerInfo_Locale>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
+        <DCC_MapFile>3</DCC_MapFile>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_iOSDevice64)'!=''">
+        <VerInfo_Keys>CFBundleName=$(MSBuildProjectName);CFBundleDevelopmentRegion=en;CFBundleDisplayName=$(MSBuildProjectName);CFBundleIdentifier=$(MSBuildProjectName);CFBundleInfoDictionaryVersion=7.1;CFBundleVersion=1.0.0;CFBundleShortVersionString=1.0.0;CFBundlePackageType=APPL;CFBundleSignature=????;LSRequiresIPhoneOS=true;CFBundleAllowMixedLocalizations=YES;CFBundleExecutable=$(MSBuildProjectName);UIDeviceFamily=iPhone &amp; iPad;NSLocationAlwaysUsageDescription=The reason for accessing the location information of the user;NSLocationWhenInUseUsageDescription=The reason for accessing the location information of the user;NSLocationAlwaysAndWhenInUseUsageDescription=The reason for accessing the location information of the user;UIBackgroundModes=;NSContactsUsageDescription=The reason for accessing the contacts;NSPhotoLibraryUsageDescription=The reason for accessing the photo library;NSPhotoLibraryAddUsageDescription=The reason for adding to the photo library;NSCameraUsageDescription=The reason for accessing the camera;NSFaceIDUsageDescription=The reason for accessing the face id;NSMicrophoneUsageDescription=The reason for accessing the microphone;NSSiriUsageDescription=The reason for accessing Siri;ITSAppUsesNonExemptEncryption=false;NSBluetoothAlwaysUsageDescription=The reason for accessing bluetooth;NSBluetoothPeripheralUsageDescription=The reason for accessing bluetooth peripherals;NSCalendarsUsageDescription=The reason for accessing the calendar data;NSRemindersUsageDescription=The reason for accessing the reminders;NSMotionUsageDescription=The reason for accessing the accelerometer;NSSpeechRecognitionUsageDescription=The reason for requesting to send user data to Apple&apos;s speech recognition servers</VerInfo_Keys>
+        <VerInfo_UIDeviceFamily>iPhoneAndiPad</VerInfo_UIDeviceFamily>
+        <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
+        <BT_BuildType>Debug</BT_BuildType>
+        <VerInfo_BundleId>$(MSBuildProjectName)</VerInfo_BundleId>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_iOSSimARM64)'!=''">
+        <VerInfo_Keys>CFBundleName=$(MSBuildProjectName);CFBundleDevelopmentRegion=en;CFBundleDisplayName=$(MSBuildProjectName);CFBundleIdentifier=$(MSBuildProjectName);CFBundleInfoDictionaryVersion=7.1;CFBundleVersion=1.0.0;CFBundleShortVersionString=1.0.0;CFBundlePackageType=APPL;CFBundleSignature=????;LSRequiresIPhoneOS=true;CFBundleAllowMixedLocalizations=YES;CFBundleExecutable=$(MSBuildProjectName);UIDeviceFamily=iPhone &amp; iPad;NSLocationAlwaysUsageDescription=The reason for accessing the location information of the user;NSLocationWhenInUseUsageDescription=The reason for accessing the location information of the user;NSLocationAlwaysAndWhenInUseUsageDescription=The reason for accessing the location information of the user;UIBackgroundModes=;NSContactsUsageDescription=The reason for accessing the contacts;NSPhotoLibraryUsageDescription=The reason for accessing the photo library;NSPhotoLibraryAddUsageDescription=The reason for adding to the photo library;NSCameraUsageDescription=The reason for accessing the camera;NSFaceIDUsageDescription=The reason for accessing the face id;NSMicrophoneUsageDescription=The reason for accessing the microphone;NSSiriUsageDescription=The reason for accessing Siri;ITSAppUsesNonExemptEncryption=false;NSBluetoothAlwaysUsageDescription=The reason for accessing bluetooth;NSBluetoothPeripheralUsageDescription=The reason for accessing bluetooth peripherals;NSCalendarsUsageDescription=The reason for accessing the calendar data;NSRemindersUsageDescription=The reason for accessing the reminders;NSMotionUsageDescription=The reason for accessing the accelerometer;NSSpeechRecognitionUsageDescription=The reason for requesting to send user data to Apple&apos;s speech recognition servers</VerInfo_Keys>
+        <VerInfo_UIDeviceFamily>iPhoneAndiPad</VerInfo_UIDeviceFamily>
+        <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_OSX64)'!=''">
+        <VerInfo_Keys>CFBundleName=$(MSBuildProjectName);CFBundleDisplayName=$(MSBuildProjectName);CFBundleIdentifier=$(MSBuildProjectName);CFBundleVersion=1.0.0;CFBundleShortVersionString=1.0.0;CFBundlePackageType=APPL;CFBundleSignature=????;CFBundleAllowMixedLocalizations=YES;CFBundleExecutable=$(MSBuildProjectName);NSHighResolutionCapable=true;LSApplicationCategoryType=public.app-category.utilities;NSLocationUsageDescription=The reason for accessing the location information of the user;NSContactsUsageDescription=The reason for accessing the contacts;NSCalendarsUsageDescription=The reason for accessing the calendar data;NSRemindersUsageDescription=The reason for accessing the reminders;NSCameraUsageDescription=The reason for accessing the camera;NSMicrophoneUsageDescription=The reason for accessing the microphone;NSMotionUsageDescription=The reason for accessing the accelerometer;NSDesktopFolderUsageDescription=The reason for accessing the Desktop folder;NSDocumentsFolderUsageDescription=The reason for accessing the Documents folder;NSDownloadsFolderUsageDescription=The reason for accessing the Downloads folder;NSNetworkVolumesUsageDescription=The reason for accessing files on a network volume;NSRemovableVolumesUsageDescription=The reason for accessing files on a removable volume;NSSpeechRecognitionUsageDescription=The reason for requesting to send user data to Apple&apos;s speech recognition servers;ITSAppUsesNonExemptEncryption=false;NSBluetoothAlwaysUsageDescription=The reason for accessing the Bluetooth interface</VerInfo_Keys>
+        <BT_BuildType>Debug</BT_BuildType>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_OSXARM64)'!=''">
+        <VerInfo_Keys>CFBundleName=$(MSBuildProjectName);CFBundleDisplayName=$(MSBuildProjectName);CFBundleIdentifier=$(MSBuildProjectName);CFBundleVersion=1.0.0;CFBundleShortVersionString=1.0.0;CFBundlePackageType=APPL;CFBundleSignature=????;CFBundleAllowMixedLocalizations=YES;CFBundleExecutable=$(MSBuildProjectName);NSHighResolutionCapable=true;LSApplicationCategoryType=public.app-category.utilities;NSLocationUsageDescription=The reason for accessing the location information of the user;NSContactsUsageDescription=The reason for accessing the contacts;NSCalendarsUsageDescription=The reason for accessing the calendar data;NSRemindersUsageDescription=The reason for accessing the reminders;NSCameraUsageDescription=The reason for accessing the camera;NSMicrophoneUsageDescription=The reason for accessing the microphone;NSMotionUsageDescription=The reason for accessing the accelerometer;NSDesktopFolderUsageDescription=The reason for accessing the Desktop folder;NSDocumentsFolderUsageDescription=The reason for accessing the Documents folder;NSDownloadsFolderUsageDescription=The reason for accessing the Downloads folder;NSNetworkVolumesUsageDescription=The reason for accessing files on a network volume;NSRemovableVolumesUsageDescription=The reason for accessing files on a removable volume;NSSpeechRecognitionUsageDescription=The reason for requesting to send user data to Apple&apos;s speech recognition servers;ITSAppUsesNonExemptEncryption=false;NSBluetoothAlwaysUsageDescription=The reason for accessing the Bluetooth interface</VerInfo_Keys>
+        <BT_BuildType>Debug</BT_BuildType>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Win32)'!=''">
+        <DCC_UsePackage>DBEBrCore;vclwinx;DataSnapServer;ORMBrCore;fmx;emshosting;vclie;DbxCommonDriver;bindengine;IndyIPCommon;VCLRESTComponents;DBXMSSQLDriver;FireDACCommonODBC;emsclient;FireDACCommonDriver;RestCoreClient;appanalytics;IndyProtocols;vclx;DBEBrConnectionDBExpress;IndyIPClient;dbxcds;vcledge;bindcompvclwinx;emsedge;bindcompfmx;DBXFirebirdDriver;inetdb;FireDACSqliteDriver;DbxClientDriver;FireDACASADriver;soapmidas;vclactnband;fmxFireDAC;dbexpress;FireDACInfxDriver;DBXMySQLDriver;VclSmp;inet;DataSnapCommon;vcltouch;fmxase;DBXOdbcDriver;dbrtl;DBEBrConnectionADO;FireDACDBXDriver;FireDACOracleDriver;fmxdae;FireDACMSAccDriver;CustomIPTransport;FireDACMSSQLDriver;DataSnapIndy10ServerTransport;RestClientHorse;DataSnapConnectors;ORMBrDriversLinks;vcldsnap;DBXInterBaseDriver;DBEBrConnectionFireDAC;FireDACMongoDBDriver;IndySystem;FireDACTDataDriver;vcldb;vclFireDAC;bindcomp;FireDACCommon;DataSnapServerMidas;FireDACODBCDriver;emsserverresource;IndyCore;RESTBackendComponents;bindcompdbx;rtl;FireDACMySQLDriver;FireDACADSDriver;frce;RESTComponents;DBXSqliteDriver;vcl;IndyIPServer;dsnapxml;dsnapcon;DataSnapClient;DataSnapProviderClient;adortl;DBXSybaseASEDriver;DBXDb2Driver;vclimg;DataSnapFireDAC;emsclientfiredac;FireDACPgDriver;FireDAC;FireDACDSDriver;inetdbxpress;xmlrtl;tethering;bindcompvcl;dsnap;CloudService;DBXSybaseASADriver;DBXOracleDriver;FireDACDb2Driver;DBXInformixDriver;fmxobj;bindcompvclsmp;DataSnapNativeClient;DatasnapConnectorsFreePascal;soaprtl;soapserver;FireDACIBDriver;$(DCC_UsePackage)</DCC_UsePackage>
+        <DCC_Namespace>Winapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;Bde;$(DCC_Namespace)</DCC_Namespace>
+        <BT_BuildType>Debug</BT_BuildType>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
+        <VerInfo_Locale>1033</VerInfo_Locale>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Win64)'!=''">
+        <DCC_UsePackage>vclwinx;DataSnapServer;fmx;emshosting;vclie;DbxCommonDriver;bindengine;IndyIPCommon;VCLRESTComponents;DBXMSSQLDriver;FireDACCommonODBC;emsclient;FireDACCommonDriver;appanalytics;IndyProtocols;vclx;IndyIPClient;dbxcds;vcledge;bindcompvclwinx;emsedge;bindcompfmx;DBXFirebirdDriver;inetdb;FireDACSqliteDriver;DbxClientDriver;FireDACASADriver;soapmidas;vclactnband;fmxFireDAC;dbexpress;FireDACInfxDriver;DBXMySQLDriver;VclSmp;inet;DataSnapCommon;vcltouch;fmxase;DBXOdbcDriver;dbrtl;FireDACDBXDriver;FireDACOracleDriver;fmxdae;FireDACMSAccDriver;CustomIPTransport;FireDACMSSQLDriver;DataSnapIndy10ServerTransport;DataSnapConnectors;vcldsnap;DBXInterBaseDriver;FireDACMongoDBDriver;IndySystem;FireDACTDataDriver;vcldb;vclFireDAC;bindcomp;FireDACCommon;DataSnapServerMidas;FireDACODBCDriver;emsserverresource;IndyCore;RESTBackendComponents;bindcompdbx;rtl;FireDACMySQLDriver;FireDACADSDriver;RESTComponents;DBXSqliteDriver;vcl;IndyIPServer;dsnapxml;dsnapcon;DataSnapClient;DataSnapProviderClient;adortl;DBXSybaseASEDriver;DBXDb2Driver;vclimg;DataSnapFireDAC;emsclientfiredac;FireDACPgDriver;FireDAC;FireDACDSDriver;inetdbxpress;xmlrtl;tethering;bindcompvcl;dsnap;CloudService;DBXSybaseASADriver;DBXOracleDriver;FireDACDb2Driver;DBXInformixDriver;fmxobj;bindcompvclsmp;DataSnapNativeClient;DatasnapConnectorsFreePascal;soaprtl;soapserver;FireDACIBDriver;$(DCC_UsePackage)</DCC_UsePackage>
+        <DCC_Namespace>Winapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
+        <BT_BuildType>Debug</BT_BuildType>
+        <VerInfo_Locale>1033</VerInfo_Locale>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_1)'!=''">
+        <DCC_Define>DEBUG;FullDebugMode; EnableMemoryLeakReporting;$(DCC_Define)</DCC_Define>
+        <DCC_DebugDCUs>true</DCC_DebugDCUs>
+        <DCC_Optimize>false</DCC_Optimize>
+        <DCC_GenerateStackFrames>true</DCC_GenerateStackFrames>
+        <DCC_DebugInfoInExe>true</DCC_DebugInfoInExe>
+        <DCC_RemoteDebug>true</DCC_RemoteDebug>
+        <DCC_IntegerOverflowCheck>true</DCC_IntegerOverflowCheck>
+        <DCC_RangeChecking>true</DCC_RangeChecking>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_1_Win32)'!=''">
+        <DCC_RemoteDebug>false</DCC_RemoteDebug>
+        <VerInfo_Locale>1033</VerInfo_Locale>
+        <Manifest_File>(None)</Manifest_File>
+        <AppDPIAwarenessMode>none</AppDPIAwarenessMode>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_1_Win64)'!=''">
+        <VerInfo_Locale>1033</VerInfo_Locale>
+        <Manifest_File>(None)</Manifest_File>
+        <AppDPIAwarenessMode>none</AppDPIAwarenessMode>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_2)'!=''">
+        <DCC_LocalDebugSymbols>false</DCC_LocalDebugSymbols>
+        <DCC_Define>RELEASE;$(DCC_Define)</DCC_Define>
+        <DCC_SymbolReferenceInfo>0</DCC_SymbolReferenceInfo>
+        <DCC_DebugInformation>0</DCC_DebugInformation>
+    </PropertyGroup>
+    <ItemGroup>
+        <DelphiCompile Include="$(MainSource)">
+            <MainSource>MainSource</MainSource>
+        </DelphiCompile>
+        <DCCReference Include="UTestMS.Coroutine.pas"/>
+        <DCCReference Include="..\..\Source\ModernSyntax.Coroutine.pas"/>
+        <DCCReference Include="..\..\Source\ModernSyntax.pas"/>
+        <BuildConfiguration Include="Base">
+            <Key>Base</Key>
+        </BuildConfiguration>
+        <BuildConfiguration Include="Debug">
+            <Key>Cfg_1</Key>
+            <CfgParent>Base</CfgParent>
+        </BuildConfiguration>
+        <BuildConfiguration Include="Release">
+            <Key>Cfg_2</Key>
+            <CfgParent>Base</CfgParent>
+        </BuildConfiguration>
+    </ItemGroup>
+    <ProjectExtensions>
+        <Borland.Personality>Delphi.Personality.12</Borland.Personality>
+        <Borland.ProjectType>Console</Borland.ProjectType>
+        <BorlandProject>
+            <Delphi.Personality>
+                <Source>
+                    <Source Name="MainSource">PTestCoroutine.dpr</Source>
+                </Source>
+                <Excluded_Packages>
+                    <Excluded_Packages Name="$(BDSBIN)\bcboffice2k280.bpl">Embarcadero C++Builder Office 2000 Servers Package</Excluded_Packages>
+                    <Excluded_Packages Name="$(BDSBIN)\bcbofficexp280.bpl">Embarcadero C++Builder Office XP Servers Package</Excluded_Packages>
+                    <Excluded_Packages Name="$(BDSBIN)\dcloffice2k280.bpl">Microsoft Office 2000 Sample Automation Server Wrapper Components</Excluded_Packages>
+                    <Excluded_Packages Name="$(BDSBIN)\dclofficexp280.bpl">Microsoft Office XP Sample Automation Server Wrapper Components</Excluded_Packages>
+                </Excluded_Packages>
+            </Delphi.Personality>
+            <Deployment Version="5">
+                <DeployFile LocalName="$(BDS)\Redist\iossimulator\libcgunwind.1.0.dylib" Class="DependencyModule">
+                    <Platform Name="iOSSimulator">
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="$(BDS)\Redist\iossimulator\libpcre.dylib" Class="DependencyModule">
+                    <Platform Name="iOSSimulator">
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="$(BDS)\Redist\osx32\libcgunwind.1.0.dylib" Class="DependencyModule">
+                    <Platform Name="OSX32">
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="PTestCoroutine.exe" Configuration="Debug" Class="ProjectOutput">
+                    <Platform Name="Win32">
+                        <RemoteName>PTestCoroutine.exe</RemoteName>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="PTestThreading.exe" Configuration="Debug" Class="ProjectOutput"/>
+                <DeployFile LocalName="Win32\Debug\PTestThreading.exe" Configuration="Debug" Class="ProjectOutput"/>
+                <DeployFile LocalName="Win64\Debug\PTestThreading.exe" Configuration="Debug" Class="ProjectOutput"/>
+                <DeployClass Name="AdditionalDebugSymbols">
+                    <Platform Name="OSX32">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Win32">
+                        <Operation>0</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidFileProvider">
+                    <Platform Name="Android">
+                        <RemoteDir>res\xml</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\xml</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidLibnativeArmeabiFile">
+                    <Platform Name="Android">
+                        <RemoteDir>library\lib\armeabi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>library\lib\armeabi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidLibnativeArmeabiv7aFile">
+                    <Platform Name="Android64">
+                        <RemoteDir>library\lib\armeabi-v7a</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidLibnativeMipsFile">
+                    <Platform Name="Android">
+                        <RemoteDir>library\lib\mips</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>library\lib\mips</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidServiceOutput">
+                    <Platform Name="Android">
+                        <RemoteDir>library\lib\armeabi-v7a</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>library\lib\arm64-v8a</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidServiceOutput_Android32">
+                    <Platform Name="Android64">
+                        <RemoteDir>library\lib\armeabi-v7a</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidSplashImageDef">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidSplashImageDefV21">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-anydpi-v21</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-anydpi-v21</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidSplashStyles">
+                    <Platform Name="Android">
+                        <RemoteDir>res\values</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\values</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidSplashStylesV21">
+                    <Platform Name="Android">
+                        <RemoteDir>res\values-v21</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\values-v21</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidSplashStylesV31">
+                    <Platform Name="Android">
+                        <RemoteDir>res\values-v31</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\values-v31</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidSplashStylesV35">
+                    <Platform Name="Android">
+                        <RemoteDir>res\values-v35</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\values-v35</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_AdaptiveIcon">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-anydpi-v26</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-anydpi-v26</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_AdaptiveIconBackground">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_AdaptiveIconForeground">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_AdaptiveIconMonochrome">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_AdaptiveIconV33">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-anydpi-v33</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-anydpi-v33</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_Colors">
+                    <Platform Name="Android">
+                        <RemoteDir>res\values</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\values</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_ColorsDark">
+                    <Platform Name="Android">
+                        <RemoteDir>res\values-night-v21</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\values-night-v21</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_DefaultAppIcon">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_LauncherIcon144">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-xxhdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-xxhdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_LauncherIcon192">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-xxxhdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-xxxhdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_LauncherIcon36">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-ldpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-ldpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_LauncherIcon48">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-mdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-mdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_LauncherIcon72">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-hdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-hdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_LauncherIcon96">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-xhdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-xhdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_NotificationIcon24">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-mdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-mdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_NotificationIcon36">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-hdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-hdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_NotificationIcon48">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-xhdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-xhdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_NotificationIcon72">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-xxhdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-xxhdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_NotificationIcon96">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-xxxhdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-xxxhdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_SplashImage426">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-small</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-small</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_SplashImage470">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-normal</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-normal</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_SplashImage640">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-large</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-large</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_SplashImage960">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-xlarge</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-xlarge</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_Strings">
+                    <Platform Name="Android">
+                        <RemoteDir>res\values</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\values</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_VectorizedNotificationIcon">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-anydpi-v24</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-anydpi-v24</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_VectorizedSplash">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_VectorizedSplashDark">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-night-anydpi-v21</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-night-anydpi-v21</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_VectorizedSplashV31">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-anydpi-v31</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-anydpi-v31</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_VectorizedSplashV31Dark">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-night-anydpi-v31</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-night-anydpi-v31</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="DebugSymbols">
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="OSX32">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Win32">
+                        <Operation>0</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="DependencyFramework">
+                    <Platform Name="OSX32">
+                        <Operation>1</Operation>
+                        <Extensions>.framework</Extensions>
+                    </Platform>
+                    <Platform Name="OSX64">
+                        <Operation>1</Operation>
+                        <Extensions>.framework</Extensions>
+                    </Platform>
+                    <Platform Name="OSXARM64">
+                        <Operation>1</Operation>
+                        <Extensions>.framework</Extensions>
+                    </Platform>
+                    <Platform Name="Win32">
+                        <Operation>0</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="DependencyModule">
+                    <Platform Name="OSX32">
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
+                    <Platform Name="OSX64">
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
+                    <Platform Name="OSXARM64">
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
+                    <Platform Name="Win32">
+                        <Operation>0</Operation>
+                        <Extensions>.dll;.bpl</Extensions>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Required="true" Name="DependencyPackage">
+                    <Platform Name="iOSDevice32">
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
+                    <Platform Name="iOSDevice64">
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
+                    <Platform Name="OSX32">
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
+                    <Platform Name="OSX64">
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
+                    <Platform Name="OSXARM64">
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
+                    <Platform Name="Win32">
+                        <Operation>0</Operation>
+                        <Extensions>.bpl</Extensions>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="File">
+                    <Platform Name="Android">
+                        <Operation>0</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <Operation>0</Operation>
+                    </Platform>
+                    <Platform Name="iOSDevice32">
+                        <Operation>0</Operation>
+                    </Platform>
+                    <Platform Name="iOSDevice64">
+                        <Operation>0</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <Operation>0</Operation>
+                    </Platform>
+                    <Platform Name="OSX32">
+                        <Operation>0</Operation>
+                    </Platform>
+                    <Platform Name="OSX64">
+                        <Operation>0</Operation>
+                    </Platform>
+                    <Platform Name="OSXARM64">
+                        <Operation>0</Operation>
+                    </Platform>
+                    <Platform Name="Win32">
+                        <Operation>0</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectAndroidManifest">
+                    <Platform Name="Android">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectOSXDebug"/>
+                <DeployClass Name="ProjectOSXEntitlements"/>
+                <DeployClass Name="ProjectOSXInfoPList"/>
+                <DeployClass Name="ProjectOSXResource">
+                    <Platform Name="OSX32">
+                        <RemoteDir>Contents\Resources</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="OSX64">
+                        <RemoteDir>Contents\Resources</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="OSXARM64">
+                        <RemoteDir>Contents\Resources</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Required="true" Name="ProjectOutput">
+                    <Platform Name="Android">
+                        <RemoteDir>library\lib\armeabi-v7a</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>library\lib\arm64-v8a</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSDevice32">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSDevice64">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Linux64">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="OSX32">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="OSX64">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="OSXARM64">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Win32">
+                        <Operation>0</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectOutput_Android32">
+                    <Platform Name="Android64">
+                        <RemoteDir>library\lib\armeabi-v7a</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectUWPManifest">
+                    <Platform Name="Win32">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Win64">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Win64x">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="WinARM64EC">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectiOSDeviceDebug">
+                    <Platform Name="iOSDevice32">
+                        <RemoteDir>..\$(PROJECTNAME).app.dSYM\Contents\Resources\DWARF</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).app.dSYM\Contents\Resources\DWARF</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).app.dSYM\Contents\Resources\DWARF</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectiOSEntitlements"/>
+                <DeployClass Name="ProjectiOSInfoPList"/>
+                <DeployClass Name="ProjectiOSLaunchScreen"/>
+                <DeployClass Name="ProjectiOSResource">
+                    <Platform Name="iOSDevice32">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSDevice64">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="UWP_DelphiLogo150">
+                    <Platform Name="Win32">
+                        <RemoteDir>Assets</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Win64">
+                        <RemoteDir>Assets</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="WinARM64EC">
+                        <RemoteDir>Assets</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="UWP_DelphiLogo44">
+                    <Platform Name="Win32">
+                        <RemoteDir>Assets</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Win64">
+                        <RemoteDir>Assets</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="WinARM64EC">
+                        <RemoteDir>Assets</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iOS_AppStore1024">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPad_AppIcon152">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPad_AppIcon167">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPad_Launch2x">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\LaunchScreenImage.imageset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\LaunchScreenImage.imageset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPad_LaunchDark2x">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\LaunchScreenImage.imageset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\LaunchScreenImage.imageset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPad_Notification40">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPad_Setting58">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPad_SpotLight80">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPhone_AppIcon120">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPhone_AppIcon180">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPhone_Launch2x">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\LaunchScreenImage.imageset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\LaunchScreenImage.imageset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPhone_Launch3x">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\LaunchScreenImage.imageset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\LaunchScreenImage.imageset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPhone_LaunchDark2x">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\LaunchScreenImage.imageset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\LaunchScreenImage.imageset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPhone_LaunchDark3x">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\LaunchScreenImage.imageset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\LaunchScreenImage.imageset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPhone_Notification40">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPhone_Notification60">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPhone_Setting58">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPhone_Setting87">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPhone_Spotlight120">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPhone_Spotlight80">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <ProjectRoot Platform="Android" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="Android64" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="iOSDevice32" Name="$(PROJECTNAME).app"/>
+                <ProjectRoot Platform="iOSDevice64" Name="$(PROJECTNAME).app"/>
+                <ProjectRoot Platform="iOSSimARM64" Name="$(PROJECTNAME).app"/>
+                <ProjectRoot Platform="Linux64" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="OSX32" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="OSX64" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="OSXARM64" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="Win32" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="Win64" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="Win64x" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="WinARM64EC" Name="$(PROJECTNAME)"/>
+            </Deployment>
+            <Platforms>
+                <Platform value="iOSDevice64">False</Platform>
+                <Platform value="iOSSimARM64">False</Platform>
+                <Platform value="Linux64">False</Platform>
+                <Platform value="OSX64">False</Platform>
+                <Platform value="OSXARM64">False</Platform>
+                <Platform value="Win32">True</Platform>
+                <Platform value="Win64">True</Platform>
+            </Platforms>
+        </BorlandProject>
+        <ProjectFileVersion>12</ProjectFileVersion>
+    </ProjectExtensions>
+    <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')"/>
+    <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
+    <Import Project="$(MSBuildProjectName).deployproj" Condition="Exists('$(MSBuildProjectName).deployproj')"/>
+</Project>

--- a/Test Delphi/EclbrSystem/TestMSGroup.groupproj
+++ b/Test Delphi/EclbrSystem/TestMSGroup.groupproj
@@ -21,6 +21,9 @@
         <Projects Include="PTestAsync.dproj">
             <Dependencies/>
         </Projects>
+        <Projects Include="PTestCoroutine.dproj">
+            <Dependencies/>
+        </Projects>
         <Projects Include="PTestStd.dproj">
             <Dependencies/>
         </Projects>
@@ -101,6 +104,15 @@
     <Target Name="PTestAsync:Make">
         <MSBuild Projects="PTestAsync.dproj" Targets="Make"/>
     </Target>
+    <Target Name="PTestCoroutine">
+        <MSBuild Projects="PTestCoroutine.dproj"/>
+    </Target>
+    <Target Name="PTestCoroutine:Clean">
+        <MSBuild Projects="PTestCoroutine.dproj" Targets="Clean"/>
+    </Target>
+    <Target Name="PTestCoroutine:Make">
+        <MSBuild Projects="PTestCoroutine.dproj" Targets="Make"/>
+    </Target>
     <Target Name="PTestStd">
         <MSBuild Projects="PTestStd.dproj"/>
     </Target>
@@ -156,13 +168,13 @@
         <MSBuild Projects="..\..\Examples\CurryingDemo.dproj" Targets="Make"/>
     </Target>
     <Target Name="Build">
-        <CallTarget Targets="PTestMatch;PTestTuple;PTestResultPair;PTestStream;PTestObjects;PTestAsync;PTestStd;PTestSafeTry;PTestCurrying;PTestOption;PTestDotEnv;CurryingDemo"/>
+        <CallTarget Targets="PTestMatch;PTestTuple;PTestResultPair;PTestStream;PTestObjects;PTestAsync;PTestCoroutine;PTestStd;PTestSafeTry;PTestCurrying;PTestOption;PTestDotEnv;CurryingDemo"/>
     </Target>
     <Target Name="Clean">
-        <CallTarget Targets="PTestMatch:Clean;PTestTuple:Clean;PTestResultPair:Clean;PTestStream:Clean;PTestObjects:Clean;PTestAsync:Clean;PTestStd:Clean;PTestSafeTry:Clean;PTestCurrying:Clean;PTestOption:Clean;PTestDotEnv:Clean;CurryingDemo:Clean"/>
+        <CallTarget Targets="PTestMatch:Clean;PTestTuple:Clean;PTestResultPair:Clean;PTestStream:Clean;PTestObjects:Clean;PTestAsync:Clean;PTestCoroutine:Clean;PTestStd:Clean;PTestSafeTry:Clean;PTestCurrying:Clean;PTestOption:Clean;PTestDotEnv:Clean;CurryingDemo:Clean"/>
     </Target>
     <Target Name="Make">
-        <CallTarget Targets="PTestMatch:Make;PTestTuple:Make;PTestResultPair:Make;PTestStream:Make;PTestObjects:Make;PTestAsync:Make;PTestStd:Make;PTestSafeTry:Make;PTestCurrying:Make;PTestOption:Make;PTestDotEnv:Make;CurryingDemo:Make"/>
+        <CallTarget Targets="PTestMatch:Make;PTestTuple:Make;PTestResultPair:Make;PTestStream:Make;PTestObjects:Make;PTestAsync:Make;PTestCoroutine:Make;PTestStd:Make;PTestSafeTry:Make;PTestCurrying:Make;PTestOption:Make;PTestDotEnv:Make;CurryingDemo:Make"/>
     </Target>
     <Import Project="$(BDS)\Bin\CodeGear.Group.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Group.Targets')"/>
 </Project>

--- a/Test Delphi/EclbrSystem/UTestMS.Coroutine.pas
+++ b/Test Delphi/EclbrSystem/UTestMS.Coroutine.pas
@@ -1,0 +1,287 @@
+unit UTestMS.Coroutine;
+
+interface
+
+uses
+  DUnitX.TestFramework,
+  Rtti,
+  SysUtils,
+  Classes,
+  SyncObjs,
+  ModernSyntax,
+  ModernSyntax.Coroutine;
+
+type
+  [TestFixture]
+  TTestScheduler = class
+  private
+    // A FIELD, not a local: in the abandon test the coroutine outlives the call that created
+    // it, so the flag it writes has to outlive the call too.
+    FBodyFinished: Boolean;
+    procedure _RunUntilBusyThenRelease(const AEntered: TEvent; const AWorkMs: Cardinal;
+      const AShutdownMs: Cardinal);
+  public
+    [Setup]
+    procedure Setup;
+    [TearDown]
+    procedure TearDown;
+
+    // --- Stop must REPORT whether it actually stopped ---
+    [Test]
+    procedure TestStopReportsStoppedWhenTheWorkerFinishes;
+    [Test]
+    procedure TestStopReportsNotStoppedWhenTheDeadlineBlows;
+    [Test]
+    procedure TestStopOnASchedulerThatNeverRanReportsStopped;
+
+    // --- the destructor must not free what the worker can still touch ---
+    [Test]
+    procedure TestDestructorWaitsForABusyWorkerInsteadOfFreeingUnderIt;
+    [Test]
+    [IgnoreMemoryLeaks(True)]
+    procedure TestDestructorAbandonsAWorkerThatWillNotStop;
+
+    // --- Next: the deterministic, clock-free driver ---
+    [Test]
+    procedure TestNextDrivesTheSchedulerOneStepAtATimeWithoutAWorker;
+  end;
+
+implementation
+
+{ DETERMINISM (no machine-speed dependency, on purpose)
+
+  Every deadline in this fixture is compared against a Sleep, and Sleep never returns EARLY.
+  A slow machine only widens the gap, so there is no flake window:
+
+    * the "must not stop in time" tests block the coroutine for CSlowWorkMs and give Stop only
+      CTightMs. The blocked body physically cannot finish inside the deadline;
+    * nothing is timed from "when we called Run". Each test waits on an EVENT the coroutine
+      signals as it enters its body, so the deadline is only started once the worker is
+      provably inside the blocking call. Thread-pool scheduling latency cannot influence the
+      outcome;
+    * the "must succeed" waits use CGenerousMs, orders of magnitude above the work;
+    * CBusyWorkMs sits deliberately between the OLD hardcoded destructor deadline (500 ms) and
+      the new C_SHUTDOWN_TIMEOUT (5000 ms): the old destructor freed the coroutines, the list
+      and the lock while the worker was still inside Next, the new one waits;
+    * a test that leaves an orphan running drains it with CDrainMs before returning. }
+
+const
+  CTick            = 10;    // scheduler sleep between iterations: small, so tests stay quick
+  CSlowWorkMs      = 1500;  // coroutine body that ALWAYS outlives the deadlines below
+  CBusyWorkMs      = 800;   // > the old hardcoded 500 ms, << C_SHUTDOWN_TIMEOUT (5000 ms)
+  CTightMs         = 50;    // deadline CSlowWorkMs physically cannot meet
+  CGenerousMs      = 30000; // deadline a trivial coroutine cannot miss
+  CShortShutdownMs = 100;   // per-instance shutdown budget, used only by the abandon test
+  CDrainMs         = 2500;  // > CSlowWorkMs: lets an abandoned worker finish before we return
+
+procedure TTestScheduler._RunUntilBusyThenRelease(const AEntered: TEvent;
+  const AWorkMs: Cardinal; const AShutdownMs: Cardinal);
+var
+  LScheduler: IScheduler;
+begin
+  // The scheduler is built AND released inside this helper on purpose. Add and Run both return
+  // IScheduler, and Delphi keeps the hidden interface temporaries a fluent API produces alive
+  // until the enclosing method ends - so `LScheduler := nil` written in the test body would NOT
+  // be the moment of destruction, and the test would prove nothing. Returning from here is the
+  // moment of destruction, with no hidden references left.
+  FBodyFinished := False;
+  LScheduler := TScheduler.New(CTick, AShutdownMs);
+  LScheduler.Add('worker',
+    function(const ASendValue: TValue; const AValue: TValue): TFuture
+    begin
+      AEntered.SetEvent;
+      Sleep(AWorkMs);
+      FBodyFinished := True;   // written by the WORKER thread, read after destruction
+      Result.SetOk(TCompletion);
+    end,
+    0);
+  LScheduler.Run(nil);
+
+  Assert.AreEqual(TWaitResult.wrSignaled, AEntered.WaitFor(CGenerousMs),
+    'the worker has to be inside the coroutine body when the scheduler is released, ' +
+    'otherwise nothing is being tested');
+end;
+
+procedure TTestScheduler.Setup;
+begin
+  TScheduler.ResetAbandonedCount;
+  TScheduler.OnAbandon := nil;
+end;
+
+procedure TTestScheduler.TearDown;
+begin
+  TScheduler.OnAbandon := nil;
+end;
+
+procedure TTestScheduler.TestStopReportsStoppedWhenTheWorkerFinishes;
+var
+  LScheduler: IScheduler;
+begin
+  LScheduler := TScheduler.New(CTick);
+  LScheduler.Add('trivial',
+    function(const ASendValue: TValue; const AValue: TValue): TFuture
+    begin
+      Result.SetOk(TCompletion);
+    end,
+    0);
+  LScheduler.Run(nil);
+
+  Assert.IsTrue(LScheduler.Stop(CGenerousMs),
+    'a scheduler whose worker really finished must report that it stopped');
+  Assert.IsTrue(LScheduler.Stop(CGenerousMs),
+    'Stop is idempotent: asking twice still reports stopped');
+end;
+
+procedure TTestScheduler.TestStopReportsNotStoppedWhenTheDeadlineBlows;
+var
+  LScheduler: IScheduler;
+  LEntered: TEvent;
+begin
+  // Before this fix Stop was a procedure and threw away ITask.Wait's Boolean - the same defect
+  // TAsync.Await had. The caller could not tell "stopped" from "gave up waiting", and then went
+  // on to release things the coroutines were still using.
+  LEntered := TEvent.Create(nil, True, False, '');
+  try
+    LScheduler := TScheduler.New(CTick);
+    LScheduler.Add('stubborn',
+      function(const ASendValue: TValue; const AValue: TValue): TFuture
+      begin
+        LEntered.SetEvent;
+        Sleep(CSlowWorkMs);
+        Result.SetOk(TCompletion);
+      end,
+      0);
+    LScheduler.Run(nil);
+
+    Assert.AreEqual(TWaitResult.wrSignaled, LEntered.WaitFor(CGenerousMs),
+      'the worker has to be inside the coroutine body before the deadline is started');
+
+    Assert.IsFalse(LScheduler.Stop(CTightMs),
+      'the deadline blew with the worker still running: Stop must say so');
+
+    // ...and a deadline that IS long enough reports the truth too.
+    Assert.IsTrue(LScheduler.Stop(CGenerousMs),
+      'given enough time the same scheduler does stop, and reports it');
+  finally
+    LScheduler := nil;
+    LEntered.Free;
+  end;
+end;
+
+procedure TTestScheduler.TestStopOnASchedulerThatNeverRanReportsStopped;
+var
+  LScheduler: IScheduler;
+begin
+  LScheduler := TScheduler.New(CTick);
+  Assert.IsTrue(LScheduler.Stop(CTightMs),
+    'there is no worker, so there is nothing still running: stopped');
+end;
+
+procedure TTestScheduler.TestDestructorWaitsForABusyWorkerInsteadOfFreeingUnderIt;
+var
+  LEntered: TEvent;
+begin
+  // THE REGRESSION TEST. The old destructor called Stop(500), ignored the answer and then freed
+  // the coroutines, FCoroutines and FLock. With a body that takes CBusyWorkMs (> 500 ms) the
+  // worker was still inside Next, walking memory that had just been released: use-after-free on
+  // a background thread during shutdown. The destructor now waits C_SHUTDOWN_TIMEOUT.
+  LEntered := TEvent.Create(nil, True, False, '');
+  try
+    _RunUntilBusyThenRelease(LEntered, CBusyWorkMs, C_SHUTDOWN_TIMEOUT);
+
+    // THIS is the assertion that catches the old use-after-free. A UAF is silent - the old
+    // destructor freed the list and the lock at 500 ms and usually got away with it because
+    // nothing had reused the memory yet. What is NOT silent is the ordering: the destructor
+    // must not return while the worker is still inside the body. With the old Stop(500) and a
+    // body of CBusyWorkMs (800 ms) this flag is still False when the destructor has already
+    // freed everything.
+    Assert.IsTrue(FBodyFinished,
+      'the destructor returned while the coroutine body was STILL RUNNING - everything it ' +
+      'freed (coroutines, queue, lock, the instance itself) is memory the worker still uses');
+    Assert.AreEqual(0, TScheduler.AbandonedCount,
+      'and because it waited, the instance is freed normally rather than abandoned');
+  finally
+    LEntered.Free;
+  end;
+end;
+
+procedure TTestScheduler.TestDestructorAbandonsAWorkerThatWillNotStop;
+var
+  LEntered: TEvent;
+  LReportedTimeout: Cardinal;
+begin
+  // The other half of the contract. When the worker will NOT stop inside the budget, the only
+  // two options are "free memory a live thread still dereferences" and "leak". It leaks - on
+  // purpose, counted, and with a hook so the host can log it. That is why this test carries
+  // [IgnoreMemoryLeaks]: one scheduler and its coroutine are deliberately never released.
+  LReportedTimeout := 0;
+  TScheduler.OnAbandon := procedure(const ATimeoutMs: Cardinal)
+                          begin
+                            LReportedTimeout := ATimeoutMs;
+                          end;
+  LEntered := TEvent.Create(nil, True, False, '');
+  try
+    // Returning from the helper is the moment of destruction; the body still has CSlowWorkMs
+    // to go, so the CShortShutdownMs budget provably blows.
+    _RunUntilBusyThenRelease(LEntered, CSlowWorkMs, CShortShutdownMs);
+
+    Assert.IsFalse(FBodyFinished,
+      'the premise of this test: the destructor gave up while the body was still running');
+    Assert.AreEqual(1, TScheduler.AbandonedCount,
+      'a worker that will not stop must be ABANDONED, never freed from under');
+    Assert.AreEqual(Integer(CShortShutdownMs), Integer(LReportedTimeout),
+      'the hook reports the deadline that was blown, so the host can log it');
+
+    // No AV and no corruption is the actual assertion: the orphan below keeps running against
+    // the instance, the coroutine list and the lock, all of which are still valid memory
+    // precisely because the destructor refused to free them.
+    Sleep(CDrainMs);
+  finally
+    TScheduler.OnAbandon := nil;
+    LEntered.Free;
+  end;
+end;
+
+procedure TTestScheduler.TestNextDrivesTheSchedulerOneStepAtATimeWithoutAWorker;
+var
+  LScheduler: IScheduler;
+  LSteps: Integer;
+begin
+  // Next is the deterministic driver: no task, no clock, no sleep. One call, one step. This is
+  // the path to use when a test needs to control time instead of waiting for it.
+  LSteps := 0;
+  LScheduler := TScheduler.New(CTick);
+  LScheduler.Add('counter',
+    function(const ASendValue: TValue; const AValue: TValue): TFuture
+    begin
+      Inc(LSteps);
+      if LSteps >= 3 then
+        Result.SetOk(TCompletion)
+      else
+        Result.SetOk(LSteps);
+    end,
+    0);
+
+  Assert.AreEqual(1, Integer(LScheduler.Count), 'one coroutine queued, worker not started');
+
+  LScheduler.Next;
+  Assert.AreEqual(1, LSteps, 'one Next is exactly one step');
+  LScheduler.Next;
+  Assert.AreEqual(2, LSteps, 'and the step composes: the coroutine was re-queued');
+  LScheduler.Next;
+  Assert.AreEqual(3, LSteps, 'third step returns TCompletion and finishes the coroutine');
+
+  Assert.AreEqual(0, Integer(LScheduler.Count),
+    'a finished coroutine leaves the queue, so the driver knows when there is nothing left');
+
+  LScheduler.Next;
+  Assert.AreEqual(3, LSteps, 'Next on an empty scheduler is a no-op, not a fault');
+
+  Assert.IsTrue(LScheduler.Stop(CTightMs),
+    'no worker was ever started, so there is nothing left running');
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TTestScheduler);
+
+end.


### PR DESCRIPTION
## Why

The same family of defect #7 fixed in `TAsync.Await`, in two more places in
`ModernSyntax.Coroutine` — and the second one is worse than the original, because it corrupts
memory instead of merely lying about a result.

## 1. `TScheduler.Stop` threw away the answer

`Stop` discarded the `Boolean` returned by `FTask.Wait(ATimeout)` — literally the same line
shape `Await` had. The caller could not distinguish *"the scheduler stopped"* from *"I gave up
waiting"*, and then went on to release resources the coroutines were still using.

`Stop` is now a **function**:

```pascal
function Stop(const ATimeout: Cardinal = C_STOP_TIMEOUT): Boolean;
```

`False` means the coroutines are **still executing**. Calling it as a statement
(`FScheduler.Stop;` — the form used in `Examples/UCorrotina.pas:227`) still compiles, so no
caller breaks, and `TScheduler` is the only implementation of `IScheduler` in the repository.

### `Stop` can no longer hang

It used to take `FLock` before doing anything. If a coroutine body hung while `Next` held the
lock, the *stop request itself* blocked forever — precisely the case `Stop` has to survive.
Now:

- `FStoped` is published **outside** the lock. It is a plain `Boolean` the worker only polls,
  and `Run`'s `while (not FStoped)` already read it unsynchronised, so this is not a new race;
- the lock is taken only for the un-pause walk over `FCoroutines`, with a bounded budget
  (`_TryAcquireLock`, `C_STOP_LOCK_BUDGET = 250 ms`). Skipping that walk costs nothing for
  termination — the loop exits on `FStoped` regardless of any paused state.

### Fixed a latent default mismatch found on the way

`IScheduler.Stop` defaulted to `1000` while `TScheduler.Stop` defaulted to `500`, so the
deadline you actually got depended on whether the call entered through the interface or the
class. Every caller goes through the interface, so `1000` was the effective default. Both now
use one constant, `C_STOP_TIMEOUT`.

## 2. The destructor freed memory the worker was still using

```pascal
destructor TScheduler.Destroy;       // before
begin
  Stop(500);                         // answer ignored
  for LItem in FCoroutines do LItem.Free;
  FCoroutines.Free;
  FLock.Free;
  inherited;                         // ...and this frees the instance itself
end;
```

The worker started by `Run` dereferences `Self` on every iteration: it reads `FStoped`, calls
`Next` (which takes `FLock` and walks `FCoroutines`), then `FOnFinished`. Any worker that had
not finished within 500 ms was left walking released memory — **use-after-free at shutdown, on
a background thread**, the hardest possible place to diagnose. And `inherited` released the
instance too, so it was not just the list and the lock.

### The decision, and why

There is no third option: either the destructor waits until the worker is provably done, or it
must not touch anything the worker can reach. Waiting *forever* is not acceptable either — a
coroutine body that never returns would hang process shutdown with no way out. So, in order:

1. **ask to stop and wait `FShutdownTimeout`** — default `C_SHUTDOWN_TIMEOUT = 5000 ms`, ten
   times the old deadline, and tunable per instance through `TScheduler.New`'s second parameter
   for callers with a tighter shutdown budget;
2. **it stopped** → free everything exactly as before;
3. **it did not stop** → **abandon**: free nothing, count it, fire the hook.

Abandoning includes an override of `FreeInstance`. `TObject.FreeInstance` is
`CleanupInstance + _FreeMem`, so skipping it keeps **both** the object storage and its managed
fields (`FTask`, the `TValue`s, the closures) alive — which is the point, because those are
exactly what the running worker still dereferences. A leaked scheduler is bounded, countable
and diagnosable; heap corruption driven by a live background thread is none of those.

`ITask.Wait` re-raises whatever the worker raised, and a destructor must not propagate — so the
wait is guarded, and a faulted task counts as **finished**, which is the only property the
decision depends on.

### Diagnostics without choosing an I/O channel

A destructor writing to `stderr` in a GUI process is its own kind of bug, so the unit does not
pick one:

- `class function TScheduler.AbandonedCount: Integer`
- `class procedure TScheduler.ResetAbandonedCount`
- `class property TScheduler.OnAbandon: TSchedulerAbandonEvent` — receives the deadline that was
  blown; exceptions from the handler are swallowed.

A non-zero `AbandonedCount` is a bug report about the **host**, not the scheduler: some
coroutine is not yielding.

## Tests — new `PTestCoroutine` project

There was no Coroutine suite at all. Added `PTestCoroutine.dpr` / `.dproj` /
`UTestMS.Coroutine.pas`, and registered the project in `TestMSGroup.groupproj`.

| test | asserts |
|---|---|
| `TestStopReportsStoppedWhenTheWorkerFinishes` | `True`, and idempotent on a second call |
| `TestStopReportsNotStoppedWhenTheDeadlineBlows` | `False` with the body still running; `True` once given a real deadline |
| `TestStopOnASchedulerThatNeverRanReportsStopped` | nothing running, so `True` |
| `TestDestructorWaitsForABusyWorkerInsteadOfFreeingUnderIt` | the destructor did **not** return while the body was running, and did not abandon |
| `TestDestructorAbandonsAWorkerThatWillNotStop` | abandoned, counted, hook reports the blown deadline, no AV |
| `TestNextDrivesTheSchedulerOneStepAtATimeWithoutAWorker` | one `Next` = one step; queue empties on `TCompletion`; `Next` on an empty scheduler is a no-op |

### Determinism, by construction

- every deadline is compared against a `Sleep`, and `Sleep` never returns **early** — a slow
  machine only widens the gap;
- **nothing is timed from `Run`.** Each test waits on an event the coroutine signals as it
  *enters* its body, so thread-pool scheduling latency cannot influence the outcome;
- the "must succeed" waits use 30 s, orders of magnitude above the work;
- `CBusyWorkMs = 800` sits deliberately between the old hardcoded 500 ms and the new 5000 ms;
- the abandon test drains its orphan before returning.

### Catching a silent use-after-free

A UAF is silent — the old destructor freed the list and the lock at 500 ms and usually got away
with it because nothing had reused the memory yet. What is **not** silent is the ordering, so
that is what is asserted: a flag written by the worker at the end of its body must already be
set when the destructor returns.

### Two things that nearly invalidated the tests, both documented in the code

- `Add` and `Run` both return `IScheduler`, and Delphi keeps the hidden interface temporaries a
  fluent API produces alive **until the end of the enclosing method**. `LScheduler := nil` in a
  test body is therefore *not* the point of destruction. The scheduler is built and released
  inside a helper; returning from the helper is the point of destruction.
- `PTestCoroutine` deliberately does **not** link `FastMM4`, unlike its sibling projects: the
  abandon test leaks one scheduler on purpose — that is the behaviour under test — and FastMM's
  shutdown leak report would flag it as a failure. The test also carries
  `[IgnoreMemoryLeaks(True)]` for DUnitX.

## Counterproof

With the destructor reverted to the old `Stop(500)`-ignoring-the-answer body, **2 of the 6
tests fail**: *"the destructor returned while the coroutine body was STILL RUNNING"* and the
abandon test.

## Gate

| | result |
|---|---|
| `PTestCoroutine` (Win32, Delphi 12) | **6 / 6** (new) |
| `PTestAsync` | **14 / 14** |
| `PTestResultPair` | **27 / 27** |
| All 16 `Source` units, Win32 | compile clean (only the pre-existing `H2509` hint in `ModernSyntax.Option.pas:61`) |
| All 16 `Source` units, Win64 | compile clean (same pre-existing hint) |
| `ModernSyntax.Coroutine`, `dcclinux64` | compile clean |

The Axial suite was **not** run — another agent is writing in that clone.

## Note on the CHANGELOG

PR #9 introduces `CHANGELOG.md`. This branch is cut from `main` and does not touch it, to avoid
a conflict; fold an entry for `IScheduler.Stop` becoming a function (a source-compatible but
signature-level change) into `[Unreleased]` when both land.
