### PR TITLE
fix(license): declare MIT consistently across headers, SBOM and manifests

### DIFF
--- a/Source/ModernSyntax.inc
+++ b/Source/ModernSyntax.inc
@@ -1,20 +1,14 @@
 {
-      ModernSyntax - Functional Programming Toolkit for Delphi
+  ------------------------------------------------------------------------------
+  ModernSyntax
+  Functional programming toolkit and modern syntax extension for Delphi.
 
-                   Copyright (c) 2016, Isaque Pinheiro
-                          All rights reserved.
+  SPDX-License-Identifier: MIT
+  Copyright (c) 2025-2026 Isaque Pinheiro
 
-                    GNU Lesser General Public License
-                      Versão 3, 29 de junho de 2007
-
-       Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
-       A todos é permitido copiar e distribuir cópias deste documento de
-       licença, mas mudá-lo não é permitido.
-
-       Esta versão da GNU Lesser General Public License incorpora
-       os termos e condições da versão 3 da GNU General Public License
-       Licença, complementado pelas permissões adicionais listadas no
-       arquivo LICENSE na pasta principal.
+  Licensed under the MIT License.
+  See the LICENSE file in the project root for full license information.
+  ------------------------------------------------------------------------------
 }
 
 {
@@ -263,8 +257,8 @@
 
 {$IFDEF DELPHI17_UP}
   {$DEFINE HAS_NET_ENCODING}
-{$ELSE IFDEF DELPHI16_UP}
+{$ELSEIF Defined(DELPHI16_UP)}
   {$DEFINE HAS_SOAP_ENCODING}
-{$ELSE
+{$ELSE}
   {$DEFINE HAS_ENCDDECD}
 {$ENDIF}

--- a/boss.json
+++ b/boss.json
@@ -3,6 +3,7 @@
   "description": "ModernSyntax brings modern, fluent, and expressive syntax to Delphi, making code cleaner and development more productive.",
   "version": "1.0.0",
   "homepage": "https://github.com/ModernDelphiWorks/ModernSyntax",
+  "license": "MIT",
   "mainsrc": "./Source",
   "projects": [],
   "dependencies": {}

--- a/pubpascal.json
+++ b/pubpascal.json
@@ -3,6 +3,7 @@
   "name": "ModernSyntax",
   "version": "1.1.0",
   "kind": "runtime",
+  "license": "MIT",
   "sources": ["./Source/"],
   "platforms": ["Win32", "Win64"],
   "dependencies": {}

--- a/sbom/modernsyntax-1.1.0.cdx.json
+++ b/sbom/modernsyntax-1.1.0.cdx.json
@@ -9,9 +9,16 @@
       }
     ],
     "component": {
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
       "name": "ModernSyntax",
       "purl": "pkg:github/ModernDelphiWorks/ModernSyntax@1.1.0",
-      "type": "application",
+      "type": "library",
       "version": "1.1.0"
     },
     "timestamp": "2026-06-10T00:37:02.396Z"


### PR DESCRIPTION
## Why

The repository **is** MIT — `LICENSE`, the README badge (`README.md:4`), and the `SPDX-License-Identifier: MIT` line carried by all 16 `Source/*.pas`. But four places still said something else, or said nothing at all.

A wrong or missing licence declaration is a supply-chain defect, not cosmetics, so it gets its own commit with "license" in the subject line — a licence correction has to be auditable from outside, in `git log`, not buried inside a PR about something else.

## What changed

### 1. `Source/ModernSyntax.inc` — the last non-MIT text in the repo

| Before | After |
|---|---|
| `GNU Lesser General Public License, Versão 3` + FSF paragraph (lines 7–17) | the MIT header used verbatim by the 16 `.pas` files |
| `Copyright (c) 2016` | `Copyright (c) 2025-2026` — matches `LICENSE:3` |
| `All rights reserved.` | dropped — it contradicts a permissive licence |
| no SPDX line | `SPDX-License-Identifier: MIT` on **line 6**, exactly where the 16 `.pas` carry it |

This was the **only** non-MIT licence text anywhere in the repository, and `.inc` was the **only** file under `Source/` without an SPDX tag.

Side effect: the file is now pure ASCII (the old LGPL text held UTF-8 accents in a no-BOM source).

### 2. `sbom/modernsyntax-1.1.0.cdx.json` — the item with real-world teeth

The CycloneDX document declared **no licence anywhere** — `metadata.component` had only `name`/`purl`/`type`/`version`, and `components: []`. That is the one that actually matters: `README.md:5` advertises a **"CRA-ready — SBOM + Security policy"** badge, and the SBOM is precisely the artefact a compliance scanner reads by machine. A CRA-ready badge over a licence-silent SBOM is a claim the artefact does not back.

- Declares MIT via the CycloneDX licence-choice form: `metadata.component.licenses[].license.id = "MIT"`.
- `metadata.component.type`: `"application"` → `"library"`. ModernSyntax is a runtime library (`pubpascal.json` says `"kind": "runtime"`); nothing here produces an application.
- **Verified valid against the official CycloneDX 1.5 JSON schema** (`CycloneDX/specification` `bom-1.5.schema.json`, with the `spdx` and `jsf-0.82` `$ref`s resolved).

**Decision — the SBOM stays pinned at `1.1.0`, on purpose.** It is generator output (`metadata.tools` = PubDelphi 0.18.0, with a real `timestamp`). Hand-bumping it to the current tag would forge a generator run: the timestamp would be a lie, and it would claim to describe a version whose inventory nobody re-scanned. Declaring MIT on the 1.1.0 document, by contrast, is *retroactively correct* — `LICENSE` was already MIT at `v1.1.0` (`git show v1.1.0:LICENSE`), so this documents what 1.1.0 shipped under rather than asserting anything new.

Re-cutting the SBOM for the current tag is its own slice, and it cannot be done in isolation, because the version story is a **four-way** disagreement:

| source | version |
|---|---|
| git tag | `v1.2.0` |
| `pubpascal.json` | `1.1.0` |
| `boss.json` | `1.0.0` |
| this SBOM | `1.1.0` |

That needs PubDelphi to regenerate and a decision on which manifest is canonical — out of scope for a licence fix.

### 3. `boss.json` / `pubpascal.json` — neither declared a licence

Both now say `"license": "MIT"`.

- **`pubpascal.json`** — schema-sanctioned. The manifest schema the file `$schema`-references defines `"license": { "type": "string" }`. (Note the referenced URL, `https://www.pubdelphi.dev/schema/pubdelphi.schema.json`, does not resolve — `pubdelphi.dev` is NXDOMAIN and `pubpascal.dev/schema/pubdelphi.schema.json` 404s. The live schema is `pubpascal.schema.json`. That stale `$schema` URL is repeated across ~10 ModernDelphiWorks packages, so it is an ecosystem-wide fix, not this PR's.)
- **`boss.json`** — house precedent, with a caveat. Boss's manifest struct (`HashLoad/boss`, `internal/core/domain/package.go`) has **no** `License` field and Boss ships no manifest schema, so the key is silently ignored on load. It is still what the house does: `HashLoad/horse` and `ModernDelphiWorks/FluentSQL` both carry `"license": "MIT"`. Caveat worth recording: `FilePackageRepository.Save` re-marshals the struct, so a future `boss install` would drop the key. It is a human/scanner-facing declaration, not a Boss feature.

## Also here: `.inc` preprocessor hygiene, same file, zero runtime impact

`Source/ModernSyntax.inc` had two mistakes in the encoding-symbol chain that compile with **zero errors and zero warnings**:

```pascal
{$IFDEF DELPHI17_UP}
  {$DEFINE HAS_NET_ENCODING}
{$ELSE IFDEF DELPHI16_UP}    // NOT $ELSEIF - text after $ELSE is ignored,
  {$DEFINE HAS_SOAP_ENCODING} // so this branch was unconditional
{$ELSE                        // missing closing brace - swallows the next line,
  {$DEFINE HAS_ENCDDECD}      // so HAS_ENCDDECD was NEVER defined, on any compiler
{$ENDIF}
```

Now `{$ELSEIF Defined(DELPHI16_UP)}` and `{$ELSE}`.

**Confirmed unobservable before touching it**, on both axes:
- the `.inc` is included by exactly one unit — `Source/ModernSyntax.Objects.pas:16`;
- **no** unit in `Source/`, `Examples/` or `Test Delphi/` reads `HAS_NET_ENCODING`, `HAS_SOAP_ENCODING`, `HAS_ENCDDECD`, `FORMATSETTINGS`, `HAS_FMX`, `HAS_VCL`, `LOAD_DYNAMICALLY` or any `DELPHI*_UP` symbol.

### Deliberately NOT fixed: the `{$IFDEF FCP}` typo in the same file

Correcting it to `FPC` would **not** be a no-op — it would switch **on** an FPC-to-Delphi-2010 feature mapping that has never been compiled here. Removing wrong behaviour is safe; switching on untested compatibility is not. Left for whoever adds a real FPC target with a build that proves it.

## Gate

- `dcc32` **and** `dcc64` (RAD Studio 37.0) build all 16 `Source` units clean on **Win32** and **Win64** — only the pre-existing `H2509` at `ModernSyntax.Option.pas:61`, matching the baseline taken on pristine `main`.
- `PTestAsync` **14/14**, `PTestResultPair` **27/27** — 0 failed, 0 errored, 0 leaked.

## Conflicts

Open PR #9 also touches `Source/ModernSyntax.inc`, adding a comment block immediately above `{$IFDEF FCP}` (around line 255). This PR's hunks are the file header (lines 1–18) and the `$ELSEIF` chain (lines 264–270) — no overlapping context, so the two merge cleanly in either order. No other file here is touched by #9 or #10.
