### PR TITLE
fix(option): restore the accented bytes in the Flatten error message (mojibake reaching end users)

### DIFF
--- a/Source/ModernSyntax.Option.pas
+++ b/Source/ModernSyntax.Option.pas
@@ -437,7 +437,7 @@ begin
     if LInner.IsType<TOption<U>> then
       Result := LInner.AsType<TOption<U>>
     else
-      raise Exception.Create('Flatten sï¿½ pode ser usado quando T ï¿½ TOption<U>');
+      raise Exception.Create('Flatten só pode ser usado quando T é TOption<U>');
   end
   else
     Result := TOption<U>.None;


### PR DESCRIPTION
## The damage reaches the end user

`Source/ModernSyntax.Option.pas:440` is the only encoding damage in this repository that a user can actually observe, because it sits **inside a string literal raised as a runtime exception** — not inside a comment.

```pascal
raise Exception.Create('Flatten s? pode ser usado quando T ? TOption<U>');
```

| release | bytes | what the literal holds |
|---|---|---|
| `v1.1.0` | CP1252, no BOM | `s` + **`0xF3`** (ó), `T` + **`0xE9`** (é) — correct |
| `v1.2.0` → `main` | UTF-8, no BOM | each accent replaced by **`U+FFFD`** (`EF BF BD`) |

`dcc` reads a BOM-less source as ANSI, so the three UTF-8 bytes of each `U+FFFD` are decoded as **three separate CP1252 characters**. Anyone who hits this exception reads:

```
Flatten sï¿½ pode ser usado quando T ï¿½ TOption<U>
```

The message grows from **47 to 51** characters. This is in a **published release (v1.2.0)** — not a regression from any recent PR.

## The fix

The two bytes are restored to CP1252 (`0xF3`, `0xE9`), **byte-for-byte identical to the `v1.1.0` line** (verified with `cmp` against `git show v1.1.0:Source/ModernSyntax.Option.pas`). The file stays BOM-less with CRLF endings; the diff is one line.

House convention, **measured rather than assumed**: of the 21 non-ASCII source files in the repository, **13 are CP1252** and **zero** carry a BOM.

## Proof from the compiled binary, not the editor

A harness triggers `TOption<Integer>.Some(42).Flatten<string>` and dumps the runtime message, the ordinal of every non-ASCII character, and the UTF-8 bytes:

**Before (`main`)**
```
LENGTH  : 51
NON-ASCII: [10]=U+00EF(ï) [11]=U+00BF(¿) [12]=U+00BD(½) [38]=U+00EF(ï) [39]=U+00BF(¿) [40]=U+00BD(½)
UTF8HEX : 46 6C 61 74 74 65 6E 20 73 C3 AF C2 BF C2 BD 20 70 6F 64 65 ...
VERDICT : FAIL - message does not match expected text
```

**After (this branch)**
```
LENGTH  : 47
NON-ASCII: [10]=U+00F3(ó) [36]=U+00E9(é)
UTF8HEX : 46 6C 61 74 74 65 6E 20 73 C3 B3 20 70 6F 64 65 20 73 65 72 ...
VERDICT : PASS - message matches the expected accented text exactly
```

Note what the "before" run also settles: the compiled string does **not** contain `U+FFFD` at runtime — it contains `ï`, `¿`, `½` as three real characters, which is exactly the `ï¿½` a user sees. The 51-vs-47 length gap is the three-for-one expansion, twice.

## Repository-wide U+FFFD sweep

Three files carried one. All found, all accounted for:

| file | context | action |
|---|---|---|
| `Source/ModernSyntax.Option.pas:440` | **string literal** | **fixed here** |
| `Test Delphi/EclbrResultPair/UTestMS.ResultPair.pas:103` | comment | already fixed by **PR #9** |
| `Test Delphi/EclbrSystem/UTestMMS.Threading.pas:168,170` | comment | already fixed by **PR #9** |

PR #9 (`docs/resultpair-known-bug-await-remarks-encoding-restore`) restores both test files to proper CP1252 — verified on that branch: bytes `E3`/`E7`/`E9`/`E1`, **zero `U+FFFD` remaining**. They are deliberately not touched here; editing them would collide with #9 and gain nothing.

**Once #9 and this PR are both in, the repository has zero `U+FFFD`.**

### Related but out of scope

Three files under `Source/` hold valid UTF-8 in a BOM-less source, so `dcc` mis-decodes them the same way — but all three are in **comments**, so nothing is observable at runtime:

- `ModernSyntax.DotEnv.pas:154` — `—` (em dash)
- `ModernSyntax.Objects.pas:534` — `não` inside a commented-out line
- `ModernSyntax.Stream.pas:248` — `’` (right single quote)

Left alone: this PR is about the literal that users read. (`ModernSyntax.inc` also held UTF-8 accents; those disappear in PR #11, which replaces that whole header block.)

## Gate

- `dcc32` **and** `dcc64` (RAD Studio 37.0) build all 16 `Source` units clean on **Win32** and **Win64** — only the pre-existing `H2509` at `ModernSyntax.Option.pas:61`, matching the baseline taken on pristine `main`.
- `PTestAsync` **14/14**, `PTestResultPair` **27/27** — 0 failed, 0 errored, 0 leaked.

## Conflicts

None. `ModernSyntax.Option.pas` is not touched by PR #9 or PR #10.
